### PR TITLE
chore: override base-x package to skip vunnerable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "overrides": {
       "cross-spawn": "^7.0.5",
       "axios": "^1.8.4",
-      "image-size": "^1.2.1"
+      "image-size": "^1.2.1",
+      "base-x": ">=4.0.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   cross-spawn: ^7.0.5
   axios: ^1.8.4
   image-size: ^1.2.1
+  base-x: '>=4.0.1'
 
 importers:
 
@@ -2962,9 +2963,6 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  base-x@4.0.0:
-    resolution: {integrity: sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==}
 
   base-x@5.0.1:
     resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
@@ -10528,8 +10526,6 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  base-x@4.0.0: {}
-
   base-x@5.0.1: {}
 
   base58-js@1.0.5: {}
@@ -10611,7 +10607,7 @@ snapshots:
 
   bs58@5.0.0:
     dependencies:
-      base-x: 4.0.0
+      base-x: 5.0.1
 
   bs58@6.0.0:
     dependencies:


### PR DESCRIPTION
<img width="593" alt="Screenshot 2025-05-21 at 12 12 42" src="https://github.com/user-attachments/assets/316eb26f-9109-4218-a22e-dd56b2502cb3" />
