### PR TITLE
chore: update workflow action refs for org transfer

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -47,7 +47,7 @@ runs:
         fetch-depth: 0
         path: ${{ github.workspace }}
     - name: Setup Node
-      uses: dynamic-labs/sdk/.github/actions/setup-node@main
+      uses: dynamic-labs-oss/public-wallet-connectors/.github/actions/setup-node@main
       with:
         version: ${{ inputs.version }}
     - name: Install Packages for Github Action

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Bump Versions
         env:
           ACTIONS_RUNNER_DEBUG: true
-        uses: dynamic-labs/sdk/.github/actions/release@main
+        uses: dynamic-labs-oss/public-wallet-connectors/.github/actions/release@main
         id: bumpversion
         with:
           type: bump

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -23,7 +23,7 @@ jobs:
           ACTIONS_RUNNER_DEBUG: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-        uses: dynamic-labs/sdk/.github/actions/release@main
+        uses: dynamic-labs-oss/public-wallet-connectors/.github/actions/release@main
         with:
           type: publish
           ref: ${{ github.event.inputs.ref }}


### PR DESCRIPTION
## Summary
- Update action references from `dynamic-labs/sdk` to `dynamic-labs-oss/public-wallet-connectors` in preparation for transferring the repo to the `dynamic-labs-oss` org
- Updates `publish-packages.yml`, `bump-version.yml`, and `action.yml`

## Test plan
- [ ] Merge this PR
- [ ] Transfer the repo to `dynamic-labs-oss`
- [ ] Trigger `Bump Versions` workflow manually to verify it works
- [ ] Trigger `Publish Packages` workflow to verify publishing works

🤖 Generated with [Claude Code](https://claude.com/claude-code)