### PR TITLE
chore: move publish-packages permissions to job level

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -7,17 +7,16 @@ on:
         description: Branch or commit to publish. The ref must be a chore(release) commit
         default: main
 
-permissions:
-  id-token: write # Required for OIDC
-  contents: write
-  actions: read
-  deployments: write
-  packages: write
-
 jobs:
   publish:
     environment: release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC
+      contents: write
+      actions: read
+      deployments: write
+      packages: write
     steps:
       - name: Publish
         env:


### PR DESCRIPTION
## Summary
- Moves the `permissions:` block from workflow scope into the `publish` job.

## Why
The `Publish Packages` workflow has been failing at the `createRelease` REST call with:

```
HTTP 403 Resource not accessible by integration
x-accepted-github-permissions: contents=write; contents=write,workflows=write
```

despite the runner reporting `Contents: write` on `GITHUB_TOKEN`. The last successful run (`24847058685`) was dispatched on a commit that did **not** modify workflow files; every run since #137 (which modified this file) has failed on the release step even after clearing the existing tag/release.

The sibling `dynamic-labs/dynamic-auth` `publish-packages.yml` declares its permissions at the **job** level and is unaffected. The combination here (workflow-scoped `permissions:` + job-scoped `environment: release`) is a known Actions quirk where the workflow-level declaration doesn't fully propagate.

Moving the block inside the job — matching the dynamic-auth pattern — is the minimal targeted fix.

## Test plan
- [ ] Manually dispatch the `Publish Packages` workflow from `main` after this PR merges.
- [ ] Verify the `Create Release` step succeeds and `v4.6.0` (or next version) is published.
- [ ] Confirm the npm OIDC publish step runs and all 11 `@dynamic-labs-connectors/*` packages are published.