### PR TITLE
chore: add workflows:write to publish-packages permissions

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -17,6 +17,11 @@ jobs:
       actions: read
       deployments: write
       packages: write
+      # Required when the workflow run was triggered by a commit that
+      # modifies files under .github/workflows/. The Create a Release
+      # REST endpoint then requires contents:write + workflows:write —
+      # see https://docs.github.com/en/rest/releases/releases#create-a-release
+      workflows: write
     steps:
       - name: Publish
         env:


### PR DESCRIPTION
## Summary
Adds `workflows: write` to the `publish` job's permissions block.

## Why
[GitHub's `Create a release` endpoint docs](https://docs.github.com/en/rest/releases/releases?apiVersion=2026-03-10#create-a-release) document two acceptable permission sets:

> The fine-grained token must have **at least one of** the following permission sets:
> - "Contents" repository permissions (write)
> - "Contents" repository permissions (write) **and** "Workflows" repository permissions (write)

The 403 responses our workflow has been receiving include this hint header:

```
x-accepted-github-permissions: contents=write; contents=write,workflows=write
```

GitHub selects the required set per request. Correlation across every dispatch of `Publish Packages`:

| Run head SHA | Modifies `.github/workflows/*` ? | Result |
|---|---|---|
| `7ecd4df` (16:38 — last success) | no (only `package.json` bumps) | ✅ `contents: write` sufficed |
| `b3232cab` (PR #137) | yes | ❌ 403 |
| `3d5d215c` (PR #138, post–job-level-permissions) | yes | ❌ 403 |

When the workflow run is triggered on a commit that modifies workflow files, the API promotes the requirement to the second set. Without `workflows: write`, `createRelease` fails before npm publish can even run.

## Test plan
- [ ] Manually dispatch `Publish Packages` from `main` after this PR merges.
- [ ] Confirm the `Create Release` step succeeds and `v4.6.0` (or the next version bump) is published.
- [ ] Confirm the OIDC npm publish runs and all 11 `@dynamic-labs-connectors/*` packages publish.