### PR TITLE
Revert "chore: add workflows:write to publish-packages permissions (#139)"

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -17,11 +17,6 @@ jobs:
       actions: read
       deployments: write
       packages: write
-      # Required when the workflow run was triggered by a commit that
-      # modifies files under .github/workflows/. The Create a Release
-      # REST endpoint then requires contents:write + workflows:write —
-      # see https://docs.github.com/en/rest/releases/releases#create-a-release
-      workflows: write
     steps:
       - name: Publish
         env:


### PR DESCRIPTION
## Summary
Reverts #139.

## Why
`workflows` is not a valid key in the GITHUB_TOKEN `permissions:` block. Only the keys listed in [Permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions-for-the-github_token) are accepted (actions, attestations, checks, contents, deployments, discussions, id-token, issues, packages, pages, pull-requests, repository-projects, security-events, statuses). `workflows` is a permission scope for **fine-grained PATs / GitHub Apps**, not for GITHUB_TOKEN.

The merge broke workflow file validation:

> Invalid workflow file (Line: 24, Col: 7): Unexpected value 'workflows'

Reverting to unbreak CI. The root-cause work for the `createRelease` 403 needs a different fix.