### PR TITLE
chore: bump pnpm action-setup to v10 for npm OIDC support

### DIFF
--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -11,7 +11,7 @@ runs:
     - uses: nrwl/nx-set-shas@v4
     - uses: pnpm/action-setup@v4
       with:
-        version: 9
+        version: 10
         run_install: |
           - recursive: true
             args: [--frozen-lockfile, --strict-peer-dependencies]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       # Cache node_modules
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
Upgrades `pnpm/action-setup@v4` from `version: 9` → `version: 10` in both places:
- `.github/actions/setup-node/action.yaml` (used by the release action)
- `.github/workflows/test.yml`

## Why
After #137 / #138 / the `workflows:write` work, `createRelease` now succeeds, but all 11 `pnpm publish` calls fail with:

```
Not Found - PUT https://registry.npmjs.org/@dynamic-labs-connectors%2f<pkg>
code: E404
```

Diagnosis from the latest run (`24855404573`):
- The job is running **pnpm 9.15.9**.
- npm Trusted Publishing (OIDC) support landed in **pnpm 10.14.0**. pnpm 9 cannot perform the OIDC token exchange.
- With #137 having (correctly) removed the static `NODE_AUTH_TOKEN`, `actions/setup-node@v4` still writes the literal placeholder `${NODE_AUTH_TOKEN}` into `.npmrc`. pnpm 9 sends that placeholder string as the auth token, and npm returns 404 — its standard masked response for unauthorized publish.
- Trusted publishing IS configured on npm's side for every `@dynamic-labs-connectors/*` package, so once pnpm 10 performs the OIDC exchange at publish time, the publishes should succeed.

Note: the run was reported as `success` because the release action calls `process.exit(0)` unconditionally, masking `core.setFailed`. Separate follow-up (Defect A) — we should also fix that to stop silently-green publishes from now on.

## Lockfile
Already at `lockfileVersion: '9.0'`, which pnpm 10 reads without regeneration. Verified locally by running `pnpm install --frozen-lockfile` with pnpm 10.27 against the existing lockfile — resolution completes (the only error hit was a 403 fetching from our private Artifactory, unrelated to lockfile format).

## Test plan
- [ ] CI `test` job passes on this PR (validates pnpm 10 against the lockfile).
- [ ] After merge, bump to v4.6.2 and dispatch `Publish Packages` from `main` — verify all 11 packages publish to npm via OIDC.
- [ ] Check an npm-published package's "Provenance" tab on npmjs.com to confirm OIDC signing worked.