### PR TITLE
chore: allowlist pnpm build scripts for pnpm 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,19 @@
       "image-size": "^1.2.1",
       "base-x": ">=4.0.1",
       "form-data": ">=4.0.4"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@swc/core",
+      "bigint-buffer",
+      "bufferutil",
+      "cbor-extract",
+      "esbuild",
+      "lefthook",
+      "nx",
+      "protobufjs",
+      "sharp",
+      "unrs-resolver",
+      "utf-8-validate"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
Adds `pnpm.onlyBuiltDependencies` to the root `package.json` with the 11 packages whose build scripts CI has been skipping under pnpm 10.

## Why
Under pnpm 9, `install` / `postinstall` / `preinstall` scripts for dependencies ran automatically. **pnpm 10 changed this default** — deps' build scripts are now skipped unless the package is explicitly allowlisted in the root `package.json` via `pnpm.onlyBuiltDependencies`. That's a deliberate supply-chain hardening in pnpm 10.

The first post-#142 run (`Bump Versions` 24856865638) surfaced the breakage:

```
╭ Warning ─────────────────────────────────────────────────────────────────────╮
│   Ignored build scripts: @swc/core@1.5.29, bigint-buffer@1.1.5,              │
│   bufferutil@4.0.9, cbor-extract@2.2.0, esbuild@0.25.9, lefthook@1.13.0,     │
│   nx@20.0.2, nx@20.1.0, protobufjs@7.5.4, sharp@0.33.5,                      │
│   unrs-resolver@1.11.1, utf-8-validate@5.0.10.                               │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed     │
│   to run scripts.                                                            │
╰──────────────────────────────────────────────────────────────────────────────╯
...
 NX   Loading "[object Object]" timed out after 10 minutes.
```

The run hung for exactly 10 minutes on `bump-version.ts` because `nx@20.0.2`'s postinstall was skipped, leaving Nx's plugin bootstrap in a state where `releaseVersion()` blocks on a plugin that can't load. Similar risk for every other native-binding package in the list (`@swc/core`, `esbuild`, `sharp`, `bigint-buffer`, etc.) on future runs.

## List sourcing
The 11 names are the exact union of the two "Ignored build scripts" warnings in that failing run — the workspace-root install and the nested `.github/actions/release` install (`esbuild@0.27.7, nx@20.0.2`). Both are covered by the root list because `.github/actions/release` is a workspace member.

`onlyBuiltDependencies` must live at the workspace root: pnpm explicitly warns that the field is ignored when placed in a child package in a workspace.

## Test plan
- [ ] CI `test` job passes (validates the install still works end-to-end with the allowlist).
- [ ] After merge, re-dispatch `Bump Versions` — the job should complete instead of hanging.
- [ ] Follow-up: re-dispatch `Publish Packages` with a fresh bump — verify OIDC publishes succeed for all 11 `@dynamic-labs-connectors/*` packages.