### PR TITLE
fix: switch to npm publish for OIDC + surface publish failures

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -82,8 +82,9 @@ runs:
       run: |-
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-    - name: Publish Packages
+    - name: Create Release and Detect Dist Tag
       if: "${{ inputs.type == 'publish' }}"
+      id: createrelease
       shell: bash
       env:
         NX_BASE:
@@ -97,6 +98,75 @@ runs:
           --fromSha=${{ steps.releasecommits.outputs.fromSha }} \
           --workspaceVersion=${{ steps.releasecommits.outputs.version }} \
           --verbose
+    - name: Build Packages
+      if: "${{ inputs.type == 'publish' }}"
+      shell: bash
+      run: |-
+        pnpm exec nx run-many --target=build --projects="@dynamic-labs-connectors/*"
+    - name: Upgrade npm for OIDC Trusted Publishing
+      # npm's Trusted Publishing (OIDC) support was stabilized in npm 11.5.1.
+      # Node 20 ships with npm ~10.8, so we upgrade before calling `npm publish`.
+      if: "${{ inputs.type == 'publish' }}"
+      shell: bash
+      run: |-
+        npm install -g npm@latest
+        echo "npm: $(npm --version)"
+    - name: Publish Packages to npm
+      if: "${{ inputs.type == 'publish' }}"
+      shell: bash
+      env:
+        DIST_TAG: ${{ steps.createrelease.outputs.distTag }}
+      run: |-
+        set -eo pipefail
+        if [ -z "$DIST_TAG" ]; then
+          echo "::error::distTag output was not set by the Create Release step"
+          exit 1
+        fi
+        echo "Publishing with dist-tag: $DIST_TAG"
+
+        FAILED=()
+        SKIPPED=()
+        PUBLISHED=()
+
+        for pkg_dir in dist/packages/@dynamic-labs-connectors/*/; do
+          [ -d "$pkg_dir" ] || continue
+          [ -f "$pkg_dir/package.json" ] || continue
+
+          PACKAGE_NAME=$(node -p "require('./${pkg_dir}package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./${pkg_dir}package.json').version")
+
+          echo "::group::${PACKAGE_NAME}@${PACKAGE_VERSION}"
+
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "Already published, skipping"
+            SKIPPED+=("${PACKAGE_NAME}@${PACKAGE_VERSION}")
+            echo "::endgroup::"
+            continue
+          fi
+
+          echo "Publishing ${PACKAGE_NAME}@${PACKAGE_VERSION}"
+          if (cd "$pkg_dir" && npm publish --tag "$DIST_TAG" --registry=https://registry.npmjs.org); then
+            PUBLISHED+=("${PACKAGE_NAME}@${PACKAGE_VERSION}")
+          else
+            echo "::error::Failed to publish ${PACKAGE_NAME}@${PACKAGE_VERSION}"
+            FAILED+=("${PACKAGE_NAME}@${PACKAGE_VERSION}")
+          fi
+          echo "::endgroup::"
+        done
+
+        echo ""
+        echo "Publish summary:"
+        echo "  Published: ${#PUBLISHED[@]}"
+        for p in "${PUBLISHED[@]}"; do echo "    - $p"; done
+        echo "  Skipped:   ${#SKIPPED[@]}"
+        for p in "${SKIPPED[@]}"; do echo "    - $p"; done
+        echo "  Failed:    ${#FAILED[@]}"
+        for p in "${FAILED[@]}"; do echo "    - $p"; done
+
+        if [ "${#FAILED[@]}" -gt 0 ]; then
+          echo "::error::${#FAILED[@]} package(s) failed to publish"
+          exit 1
+        fi
     - name: Bump Version
       if: "${{ inputs.type == 'bump' }}"
       shell: bash

--- a/.github/actions/release/src/commands/publish-packages.ts
+++ b/.github/actions/release/src/commands/publish-packages.ts
@@ -3,14 +3,14 @@ import * as core from '@actions/core';
 import { hideBin } from "yargs/helpers";
 import { getOctokit } from "@actions/github";
 import { detectTag } from "../lib/detectTag.js";
-import { releaseChangelog, releasePublish } from "nx/release/index.js";
+import { releaseChangelog } from "nx/release/index.js";
 import { NxReleaseChangelogResult } from "nx/src/command-line/release/changelog.js";
 
 const { GITHUB_WORKSPACE } = process.env
 
 /**
  * HACK:
- * 
+ *
  * Because of this function in NX https://github.com/nrwl/nx/blob/7232b392ba26ff74130170a5bec229d9ccef7005/packages/nx/src/plugins/js/utils/register.ts#L12-L47
  * The _ variable is set to 'tsx-spoof' if the file ends with tsx
  * This is to allow natural behavior when nx tries to generate the project graph and tries to `require('a.ts.file.ts)`
@@ -27,7 +27,7 @@ const createRelease = async (
   core.startGroup('Create Release');
 
   if (!process.env.GITHUB_TOKEN?.length) {
-    core.error('GITHUB_TOKEN is required to create a release');
+    throw new Error('GITHUB_TOKEN is required to create a release');
   }
 
   const oktokit = getOctokit(process.env.GITHUB_TOKEN);
@@ -114,7 +114,6 @@ const publishPackages = async () => {
   const workspaceVersion = options.workspaceVersion;
 
   // Updates the changelog according to conventional commits
-  // Also will create github release with changelog
   core.info(`Calling changelog with: ${JSON.stringify({
     version: workspaceVersion,
     to: toSha,
@@ -139,7 +138,7 @@ const publishPackages = async () => {
   });
 
   // Detect tag to use for publishing
-  // Using @dynamic-labs-connector/safe-evm as the package name for determining the latest version
+  // Using @dynamic-labs-connectors/safe-evm as the canonical package for latest-version comparison
   const distTag = await detectTag('@dynamic-labs-connectors/safe-evm', workspaceVersion);
 
   if (options.createRelease) {
@@ -149,21 +148,14 @@ const publishPackages = async () => {
     await createRelease(toSha, workspaceChangelog, distTag === 'latest', options.dryRun);
   }
 
-  const results = await releasePublish({
-    dryRun: options.dryRun,
-    tag: distTag,
-    verbose: options.verbose,
-  }); 
-
-  if (Object.entries(results).some(([_, value]) => value.code !== 0)) {
-    core.setFailed('Failed to publish packages');
-  } else {
-    core.summary.addDetails('Published', `Published packages with dist-tag: ${distTag}, version: ${workspaceVersion}`);
-    core.summary.addEOL();
-  }
+  // Expose distTag to the next workflow step, which runs `npm publish` directly
+  // so that OIDC trusted publishing engages (pnpm publish via nx does not reliably
+  // perform the OIDC exchange against registry.npmjs.org).
+  core.setOutput('distTag', distTag);
+  core.info(`Detected distTag: ${distTag} (version: ${workspaceVersion})`);
 };
 
-publishPackages().then(() => {
-  process.exit(0);
+publishPackages().catch((err) => {
+  core.setFailed(err instanceof Error ? err.message : String(err));
+  process.exit(1);
 });
-


### PR DESCRIPTION
## Summary
Two fixes in one PR. Both surfaced by the runs after #142/#143/#144:

1. **Switch `pnpm publish` → `npm publish`** so OIDC trusted publishing actually engages.
2. **Stop masking publish failures as `success`** (Defect A from the earlier analysis).

Mirrors the pattern used successfully in `dynamic-labs/dynamic-auth`'s `publish-packages.yml`.

## Why

### 1. OIDC trusted publishing wasn't engaging
Run [`24862086342`](https://github.com/dynamic-labs-oss/public-wallet-connectors/actions/runs/24862086342) (v4.6.2) ran on pnpm 10.33.2 with `id-token: write`, but every `pnpm publish` still returned HTTP 404 (npm's masked "unauthorized" response). `actions/setup-node@v4` with `registry-url` writes an `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`. With `NODE_AUTH_TOKEN` unset (removed correctly by #137), the placeholder interpolates to an empty string and pnpm treats "auth already configured" as a reason to skip the OIDC exchange.

`npm publish` (CLI 11.5.1+) does **not** share this behavior — its trusted-publishing flow engages whenever `id-token: write` is granted and `ACTIONS_ID_TOKEN_REQUEST_*` env vars are set, regardless of `.npmrc` state. dynamic-auth already does this: a plain shell loop over `dist/packages/*` running `npm publish --registry=https://registry.npmjs.org`.

### 2. Failures were silently reported as green
`publishPackages().then(() => process.exit(0))` at the tail of `publish-packages.ts` overrode every `core.setFailed(...)` call. Runs that published zero packages (run 24847058685, 24855404573, 24862086342) were all reported as `success`. This PR replaces the `.then` with a `.catch` that calls `core.setFailed` and `process.exit(1)`, and has the new shell loop collect failures and exit non-zero.

## Changes

**`.github/actions/release/src/commands/publish-packages.ts`**
- Remove `releasePublish(...)` call and its import.
- Emit `distTag` as a step output for the next workflow step.
- Replace `.then(() => process.exit(0))` with `.catch((err) => { core.setFailed(...); process.exit(1); })`.
- Upgrade the "GITHUB_TOKEN missing" check from `core.error(...)` (which was non-fatal) to a `throw`.

**`.github/actions/release/action.yml`**
- Rename `Publish Packages` → `Create Release and Detect Dist Tag` and add `id: createrelease`.
- Add `Build Packages` step: `pnpm exec nx run-many --target=build --projects="@dynamic-labs-connectors/*"`.
- Add `Upgrade npm for OIDC Trusted Publishing`: `npm install -g npm@latest` (bumps npm to 11.5.1+ for OIDC).
- Add `Publish Packages to npm` step: a shell loop that, for each `dist/packages/@dynamic-labs-connectors/*`:
  - Runs `npm view ...` for idempotency
  - Runs `npm publish --tag "$DIST_TAG" --registry=https://registry.npmjs.org`
  - Collects failures and exits non-zero if any.

## Test plan
- [ ] CI `test` job passes on this PR.
- [ ] After merge, bump to v4.6.3 and dispatch `Publish Packages` from `main`.
- [ ] Confirm `Create Release` step creates `v4.6.3` GitHub release.
- [ ] Confirm `Publish Packages to npm` step actually publishes all 11 `@dynamic-labs-connectors/*` packages (`PUBLISHED: 11` in the summary).
- [ ] Inspect an npmjs.com package page for the published version — "Provenance" tab should confirm OIDC-signed.
- [ ] Intentional-fail test (optional, separate branch): break one publish (e.g., simulate a 404 by pointing one package to an unknown registry) and confirm the run is now **red** instead of falsely-green.

## Rollback
Revert this commit. The previous state (pnpm publish + releasePublish + process.exit(0)) is restored.