### PR TITLE
fix: add repository field to every connector package.json

### DIFF
--- a/packages/@dynamic-labs-connectors/abstract-global-wallet-evm/package.json
+++ b/packages/@dynamic-labs-connectors/abstract-global-wallet-evm/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dynamic-labs-connectors/abstract-global-wallet-evm",
   "version": "4.6.3",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dynamic-labs-oss/public-wallet-connectors.git",
+    "directory": "packages/@dynamic-labs-connectors/abstract-global-wallet-evm"
+  },
   "type": "module",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/@dynamic-labs-connectors/base-account-evm/package.json
+++ b/packages/@dynamic-labs-connectors/base-account-evm/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dynamic-labs-connectors/base-account-evm",
   "version": "4.6.3",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dynamic-labs-oss/public-wallet-connectors.git",
+    "directory": "packages/@dynamic-labs-connectors/base-account-evm"
+  },
   "type": "module",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/@dynamic-labs-connectors/glyph-global-wallet-evm/package.json
+++ b/packages/@dynamic-labs-connectors/glyph-global-wallet-evm/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dynamic-labs-connectors/glyph-global-wallet-evm",
   "version": "4.6.3",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dynamic-labs-oss/public-wallet-connectors.git",
+    "directory": "packages/@dynamic-labs-connectors/glyph-global-wallet-evm"
+  },
   "type": "module",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/@dynamic-labs-connectors/intersend-evm/package.json
+++ b/packages/@dynamic-labs-connectors/intersend-evm/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dynamic-labs-connectors/intersend-evm",
   "version": "4.6.3",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dynamic-labs-oss/public-wallet-connectors.git",
+    "directory": "packages/@dynamic-labs-connectors/intersend-evm"
+  },
   "description": "Intersend EVM connector for Dynamic SDK",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/@dynamic-labs-connectors/ledger-evm/package.json
+++ b/packages/@dynamic-labs-connectors/ledger-evm/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dynamic-labs-connectors/ledger-evm",
   "version": "4.6.3",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dynamic-labs-oss/public-wallet-connectors.git",
+    "directory": "packages/@dynamic-labs-connectors/ledger-evm"
+  },
   "type": "module",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/@dynamic-labs-connectors/metamask-evm/package.json
+++ b/packages/@dynamic-labs-connectors/metamask-evm/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dynamic-labs-connectors/metamask-evm",
   "version": "4.6.3",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dynamic-labs-oss/public-wallet-connectors.git",
+    "directory": "packages/@dynamic-labs-connectors/metamask-evm"
+  },
   "type": "module",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/@dynamic-labs-connectors/metamask-solana/package.json
+++ b/packages/@dynamic-labs-connectors/metamask-solana/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dynamic-labs-connectors/metamask-solana",
   "version": "4.6.3",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dynamic-labs-oss/public-wallet-connectors.git",
+    "directory": "packages/@dynamic-labs-connectors/metamask-solana"
+  },
   "type": "module",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/@dynamic-labs-connectors/safe-evm/package.json
+++ b/packages/@dynamic-labs-connectors/safe-evm/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dynamic-labs-connectors/safe-evm",
   "version": "4.6.3",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dynamic-labs-oss/public-wallet-connectors.git",
+    "directory": "packages/@dynamic-labs-connectors/safe-evm"
+  },
   "type": "module",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/@dynamic-labs-connectors/sequence-cross-app-evm/package.json
+++ b/packages/@dynamic-labs-connectors/sequence-cross-app-evm/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dynamic-labs-connectors/sequence-cross-app-evm",
   "version": "4.6.3",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dynamic-labs-oss/public-wallet-connectors.git",
+    "directory": "packages/@dynamic-labs-connectors/sequence-cross-app-evm"
+  },
   "type": "module",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/@dynamic-labs-connectors/tap-bitcoin/package.json
+++ b/packages/@dynamic-labs-connectors/tap-bitcoin/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dynamic-labs-connectors/tap-bitcoin",
   "version": "4.6.3",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dynamic-labs-oss/public-wallet-connectors.git",
+    "directory": "packages/@dynamic-labs-connectors/tap-bitcoin"
+  },
   "type": "module",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/@dynamic-labs-connectors/xverse-starknet/package.json
+++ b/packages/@dynamic-labs-connectors/xverse-starknet/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dynamic-labs-connectors/xverse-starknet",
   "version": "4.6.3",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dynamic-labs-oss/public-wallet-connectors.git",
+    "directory": "packages/@dynamic-labs-connectors/xverse-starknet"
+  },
   "type": "module",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",


### PR DESCRIPTION
## Summary
Adds a `repository` field to every `@dynamic-labs-connectors/*` package.json so npm's provenance verification can validate the OIDC-signed sigstore bundle.

## Why
After #145, OIDC trusted publishing is finally engaging — the publish run now emits:

```
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=...
```

But the publish then fails with HTTP 422:

```
Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "",
  expected to match "https://github.com/dynamic-labs-oss/public-wallet-connectors" from provenance
```

When npm validates a provenance-signed publish, it requires the `package.json`'s `repository.url` to match the `repo` claim baked into the OIDC-signed sigstore bundle. All 11 packages had no `repository` field at all, so the check fails as `"" != "https://github.com/..."`.

## Change
Each of the 11 `packages/@dynamic-labs-connectors/*/package.json` now has:

```json
"repository": {
  "type": "git",
  "url": "git+https://github.com/dynamic-labs-oss/public-wallet-connectors.git",
  "directory": "packages/@dynamic-labs-connectors/<name>"
}
```

The `directory` subpath is the npm-recommended form for monorepo packages — npm resolves "View source on GitHub" links to the right subfolder.

## Test plan
- [ ] CI `test` job passes.
- [ ] Bump to v4.6.4 and dispatch `Publish Packages`.
- [ ] Confirm each package publishes successfully and has a "Provenance" badge on npmjs.com.