### PR TITLE
Support CAIP-2 chain IDs in MetaMask connector

### DIFF
--- a/packages/@dynamic-labs-connectors/metamask-evm/src/utils.spec.ts
+++ b/packages/@dynamic-labs-connectors/metamask-evm/src/utils.spec.ts
@@ -23,6 +23,10 @@ describe('utils', () => {
       expect(toNumericChainId('137')).toBe(137);
     });
 
+    it('should handle CAIP-2 EVM chain ID', () => {
+      expect(toNumericChainId('eip155:1')).toBe(1);
+    });
+
     it('should handle large chain ID', () => {
       expect(toNumericChainId('42161')).toBe(42161);
     });
@@ -128,6 +132,15 @@ describe('utils', () => {
       ];
       expect(buildSupportedNetworks(networks)).toEqual({
         '0x89': 'https://polygon.rpc',
+      });
+    });
+
+    it('should handle CAIP-2 EVM chain IDs', () => {
+      const networks: EvmNetwork[] = [
+        { chainId: 'eip155:8453', rpcUrls: ['https://base.rpc'] },
+      ];
+      expect(buildSupportedNetworks(networks)).toEqual({
+        '0x2105': 'https://base.rpc',
       });
     });
 

--- a/packages/@dynamic-labs-connectors/metamask-evm/src/utils.ts
+++ b/packages/@dynamic-labs-connectors/metamask-evm/src/utils.ts
@@ -24,6 +24,9 @@ export type HexChainId = `0x${string}`;
  */
 export function toNumericChainId(chainId: number | string): number {
   if (typeof chainId === 'number') return chainId;
+  if (chainId.startsWith('eip155:')) {
+    return parseInt(chainId.slice('eip155:'.length), 10);
+  }
   if (chainId.startsWith('0x')) return parseInt(chainId, 16);
   return parseInt(chainId, 10);
 }


### PR DESCRIPTION
Supports CAIP-2 EVM chain IDs such as `eip155:8453` in the MetaMask connector utilities.

Without this, `toNumericChainId` can return `NaN` for CAIP-2 IDs, which then produces invalid supported-network keys like `0xNaN`.

Changed:
- parse `eip155:*` chain IDs before converting to numbers
- keep existing numeric/string ID behavior
- add unit coverage for CAIP-2 conversion and supported network mapping

Checked with:
- `pnpm exec jest packages/@dynamic-labs-connectors/metamask-evm/src/utils.spec.ts --runInBand`
- `pnpm exec eslint packages/@dynamic-labs-connectors/metamask-evm/src/utils.ts packages/@dynamic-labs-connectors/metamask-evm/src/utils.spec.ts`
- `pnpm nx build @dynamic-labs-connectors/metamask-evm`