### PR TITLE
feat: Add setupEventListeners to MetaMask EVM and Solana Connectors

### DIFF
--- a/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.spec.ts
+++ b/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.spec.ts
@@ -36,11 +36,19 @@ jest.mock('@dynamic-labs/ethereum', () => {
 });
 
 jest.mock('./MetaMaskSdkClient.js');
+
+const mockEventListeners = {
+  handleAccountChange: jest.fn(),
+  handleChainChange: jest.fn(),
+  handleDisconnect: jest.fn(),
+};
+
 jest.mock('@dynamic-labs/wallet-connector-core', () => ({
   logger: {
     debug: jest.fn(),
     error: jest.fn(),
   },
+  eventListenerHandlers: jest.fn(() => mockEventListeners),
 }));
 
 const walletConnectorProps: EthereumWalletConnectorOpts = {
@@ -243,6 +251,77 @@ describe('MetaMaskEvmWalletConnector', () => {
       expect(mockProvider.request).toHaveBeenCalledWith({
         method: 'eth_chainId',
       });
+    });
+  });
+
+  describe('setupEventListeners', () => {
+    const buildProviderMock = () => ({
+      on: jest.fn(),
+      off: jest.fn(),
+    });
+
+    it('should noop when no provider is available', async () => {
+      (MetaMaskSdkClient.getProvider as jest.Mock).mockReturnValue(undefined);
+
+      await connector.setupEventListeners();
+
+      const { eventListenerHandlers } = jest.requireMock(
+        '@dynamic-labs/wallet-connector-core',
+      );
+      expect(eventListenerHandlers).not.toHaveBeenCalled();
+      expect(connector.teardownEventListeners).toBeUndefined();
+    });
+
+    it('should register listeners for accountsChanged/chainChanged/disconnect', async () => {
+      const providerMock = buildProviderMock();
+      (MetaMaskSdkClient.getProvider as jest.Mock).mockReturnValue(
+        providerMock,
+      );
+
+      await connector.setupEventListeners();
+
+      const { eventListenerHandlers } = jest.requireMock(
+        '@dynamic-labs/wallet-connector-core',
+      );
+      expect(eventListenerHandlers).toHaveBeenCalledWith(connector);
+
+      expect(providerMock.on).toHaveBeenCalledTimes(3);
+      expect(providerMock.on).toHaveBeenCalledWith(
+        'accountsChanged',
+        mockEventListeners.handleAccountChange,
+      );
+      expect(providerMock.on).toHaveBeenCalledWith(
+        'chainChanged',
+        mockEventListeners.handleChainChange,
+      );
+      expect(providerMock.on).toHaveBeenCalledWith(
+        'disconnect',
+        mockEventListeners.handleDisconnect,
+      );
+    });
+
+    it('teardown should remove the registered listeners via provider.off', async () => {
+      const providerMock = buildProviderMock();
+      (MetaMaskSdkClient.getProvider as jest.Mock).mockReturnValue(
+        providerMock,
+      );
+
+      await connector.setupEventListeners();
+      connector.teardownEventListeners?.();
+
+      expect(providerMock.off).toHaveBeenCalledTimes(3);
+      expect(providerMock.off).toHaveBeenCalledWith(
+        'accountsChanged',
+        mockEventListeners.handleAccountChange,
+      );
+      expect(providerMock.off).toHaveBeenCalledWith(
+        'chainChanged',
+        mockEventListeners.handleChainChange,
+      );
+      expect(providerMock.off).toHaveBeenCalledWith(
+        'disconnect',
+        mockEventListeners.handleDisconnect,
+      );
     });
   });
 

--- a/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.ts
+++ b/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.ts
@@ -1,6 +1,8 @@
 import {
+  eventListenerHandlers,
   logger,
   type GetAddressOpts,
+  type WalletConnector,
 } from '@dynamic-labs/wallet-connector-core';
 import {
   EthereumInjectedConnector,
@@ -77,6 +79,27 @@ export class MetaMaskEvmWalletConnector extends EthereumInjectedConnector {
       on: provider.on?.bind(provider),
       removeListener: provider.removeListener?.bind(provider),
     } as unknown as IEthereum;
+  }
+
+  override async setupEventListeners(): Promise<void> {
+    const provider = MetaMaskSdkClient.getProvider();
+
+    if (!provider) {
+      return;
+    }
+
+    const { handleAccountChange, handleChainChange, handleDisconnect } =
+      eventListenerHandlers(this as unknown as WalletConnector);
+
+    provider.on('accountsChanged', handleAccountChange);
+    provider.on('chainChanged', handleChainChange);
+    provider.on('disconnect', handleDisconnect);
+
+    this.teardownEventListeners = () => {
+      provider.off('accountsChanged', handleAccountChange);
+      provider.off('chainChanged', handleChainChange);
+      provider.off('disconnect', handleDisconnect);
+    };
   }
 
   override async getAddress(

--- a/packages/@dynamic-labs-connectors/metamask-solana/src/MetaMaskSolanaWalletConnector.spec.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/MetaMaskSolanaWalletConnector.spec.ts
@@ -6,12 +6,19 @@ jest.mock('@metamask/connect-solana', () => ({
   createSolanaClient: jest.fn(),
 }));
 
+const mockEventListeners = {
+  handleAccountChange: jest.fn(),
+  handleChainChange: jest.fn(),
+  handleDisconnect: jest.fn(),
+};
+
 jest.mock('@dynamic-labs/wallet-connector-core', () => ({
   logger: {
     debug: jest.fn(),
     error: jest.fn(),
     warn: jest.fn(),
   },
+  eventListenerHandlers: jest.fn(() => mockEventListeners),
 }));
 
 jest.mock('@dynamic-labs/solana-core', () => ({
@@ -160,6 +167,100 @@ describe('MetaMaskSolanaWalletConnector', () => {
       await connector.init();
 
       expect(emitSpy).toHaveBeenCalledWith('providerReady', { connector });
+    });
+  });
+
+  describe('setupEventListeners', () => {
+    const buildWalletWithEvents = () => {
+      const off = jest.fn();
+      const on = jest.fn().mockReturnValue(off);
+      const wallet = {
+        accounts: [{ address: 'SoLaNa1234' }],
+        features: {
+          'standard:events': { on },
+        },
+      };
+      return { wallet, on, off };
+    };
+
+    it('should noop when no wallet is available', () => {
+      (MetaMaskSolanaSdkClient.getWallet as jest.Mock).mockReturnValue(null);
+
+      connector.setupEventListeners();
+
+      const { eventListenerHandlers } = jest.requireMock(
+        '@dynamic-labs/wallet-connector-core',
+      );
+      expect(eventListenerHandlers).not.toHaveBeenCalled();
+      expect(connector.teardownEventListeners).toBeUndefined();
+    });
+
+    it('should noop when the wallet does not expose standard:events', () => {
+      (MetaMaskSolanaSdkClient.getWallet as jest.Mock).mockReturnValue({
+        accounts: [],
+        features: {},
+      });
+
+      connector.setupEventListeners();
+
+      const { eventListenerHandlers } = jest.requireMock(
+        '@dynamic-labs/wallet-connector-core',
+      );
+      expect(eventListenerHandlers).not.toHaveBeenCalled();
+      expect(connector.teardownEventListeners).toBeUndefined();
+    });
+
+    it("should subscribe to the wallet's change event", () => {
+      const { wallet, on } = buildWalletWithEvents();
+      (MetaMaskSolanaSdkClient.getWallet as jest.Mock).mockReturnValue(wallet);
+
+      connector.setupEventListeners();
+
+      const { eventListenerHandlers } = jest.requireMock(
+        '@dynamic-labs/wallet-connector-core',
+      );
+      expect(eventListenerHandlers).toHaveBeenCalledWith(connector);
+      expect(on).toHaveBeenCalledTimes(1);
+      expect(on).toHaveBeenCalledWith('change', expect.any(Function));
+    });
+
+    it('should forward updated account addresses to handleAccountChange', () => {
+      const { wallet, on } = buildWalletWithEvents();
+      (MetaMaskSolanaSdkClient.getWallet as jest.Mock).mockReturnValue(wallet);
+
+      connector.setupEventListeners();
+
+      const changeListener = on.mock.calls[0][1];
+      changeListener({
+        accounts: [{ address: 'SoLaNa1' }, { address: 'SoLaNa2' }],
+      });
+
+      expect(mockEventListeners.handleAccountChange).toHaveBeenCalledWith([
+        'SoLaNa1',
+        'SoLaNa2',
+      ]);
+    });
+
+    it('should ignore change events without accounts updates', () => {
+      const { wallet, on } = buildWalletWithEvents();
+      (MetaMaskSolanaSdkClient.getWallet as jest.Mock).mockReturnValue(wallet);
+
+      connector.setupEventListeners();
+
+      const changeListener = on.mock.calls[0][1];
+      changeListener({ chains: ['solana:mainnet'] });
+
+      expect(mockEventListeners.handleAccountChange).not.toHaveBeenCalled();
+    });
+
+    it('teardown should call the unsubscribe returned by on()', () => {
+      const { wallet, off } = buildWalletWithEvents();
+      (MetaMaskSolanaSdkClient.getWallet as jest.Mock).mockReturnValue(wallet);
+
+      connector.setupEventListeners();
+      connector.teardownEventListeners?.();
+
+      expect(off).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/@dynamic-labs-connectors/metamask-solana/src/MetaMaskSolanaWalletConnector.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/MetaMaskSolanaWalletConnector.ts
@@ -1,6 +1,8 @@
 import {
+  eventListenerHandlers,
   logger,
   type GetAddressOpts,
+  type WalletConnector,
 } from '@dynamic-labs/wallet-connector-core';
 import {
   SolanaWalletConnector,
@@ -9,7 +11,16 @@ import {
 } from '@dynamic-labs/solana-core';
 
 import { MetaMaskSolanaSdkClient } from './MetaMaskSolanaSdkClient.js';
+import type { WalletAccount } from './types.js';
 import { createWalletStandardAdapter } from './WalletStandardAdapter.js';
+
+type StandardEventsChangeListener = (properties: {
+  accounts?: readonly WalletAccount[];
+}) => void;
+type StandardEventsOn = (
+  event: 'change',
+  listener: StandardEventsChangeListener,
+) => () => void;
 
 function uint8ArrayToBase64(bytes: Uint8Array): string {
   let binary = '';
@@ -66,6 +77,37 @@ export class MetaMaskSolanaWalletConnector extends SolanaWalletConnector {
     this.walletConnectorEventsEmitter.emit('providerReady', {
       connector: this,
     });
+  }
+
+  override setupEventListeners(): void {
+    const wallet = MetaMaskSolanaSdkClient.getWallet();
+
+    if (!wallet) {
+      return;
+    }
+
+    const onFn = wallet.features['standard:events']?.['on'] as
+      | StandardEventsOn
+      | undefined;
+
+    if (!onFn) {
+      return;
+    }
+
+    const { handleAccountChange } = eventListenerHandlers(
+      this as unknown as WalletConnector,
+    );
+
+    const unsubscribe = onFn('change', (properties) => {
+      if (!properties.accounts) {
+        return;
+      }
+      void handleAccountChange(properties.accounts.map((a) => a.address));
+    });
+
+    this.teardownEventListeners = () => {
+      unsubscribe();
+    };
   }
 
   override async connect(): Promise<void> {


### PR DESCRIPTION
Adds missing `setupEventListeners` override to MetaMask EVM and Solana Connectors to handle accountsChanged and other lifecycle events