### PR TITLE
fix(intersend-evm): validate postMessage origin to prevent wallet-address spoofing

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,1 @@
+playground

--- a/packages/@dynamic-labs-connectors/intersend-evm/src/IntersendSdkClient.spec.ts
+++ b/packages/@dynamic-labs-connectors/intersend-evm/src/IntersendSdkClient.spec.ts
@@ -1,4 +1,7 @@
-import { IntersendSdkClient } from './IntersendSdkClient.js';
+import {
+  DEFAULT_INTERSEND_ALLOWED_ORIGINS,
+  IntersendSdkClient,
+} from './IntersendSdkClient.js';
 
 jest.mock('@dynamic-labs/wallet-connector-core', () => ({
   logger: {
@@ -6,16 +9,64 @@ jest.mock('@dynamic-labs/wallet-connector-core', () => ({
   },
 }));
 
+const ALLOWED_ORIGIN = DEFAULT_INTERSEND_ALLOWED_ORIGINS[0];
+const UNTRUSTED_ORIGIN = 'https://evil.example';
+
 const mockPostMessage = jest.fn();
 const mockAddEventListener = jest.fn();
+
+/** Handlers registered via `window.addEventListener('message', ...)`. */
+let messageHandlers: ((event: any) => void)[] = [];
+
+/**
+ * Drives the connect handshake by replaying an `INTERSEND_CONNECT_RESPONSE`
+ * back to the connect handler as soon as it registers. The response echoes the
+ * `requestId` from the outbound connect request unless overridden.
+ */
+const setupConnectResponse = (
+  payload: unknown,
+  {
+    origin = ALLOWED_ORIGIN,
+    requestId,
+  }: { origin?: string; requestId?: string } = {},
+) => {
+  mockAddEventListener.mockImplementation((event, handler) => {
+    if (event !== 'message') return;
+    messageHandlers.push(handler);
+
+    const connectCall = mockPostMessage.mock.calls.find(
+      ([msg]) => msg?.type === 'INTERSEND_CONNECT_REQUEST',
+    );
+    // The persistent handleMessage listener registers before any connect
+    // request is posted; only the connect handler should receive the response.
+    if (!connectCall) return;
+
+    handler({
+      origin,
+      source: global.window.parent,
+      data: {
+        type: 'INTERSEND_CONNECT_RESPONSE',
+        requestId: requestId ?? connectCall[0].requestId,
+        payload,
+      },
+    });
+  });
+};
 
 describe('IntersendSdkClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    messageHandlers = [];
+
     // Reset static properties
     IntersendSdkClient.isInitialized = false;
     IntersendSdkClient.intersendInfo = undefined;
+    IntersendSdkClient.walletOrigin = undefined;
     IntersendSdkClient.provider = undefined as any;
+    // Reset the (private) allowlist so tests overriding it don't leak.
+    (IntersendSdkClient as any).allowedOrigins = [
+      ...DEFAULT_INTERSEND_ALLOWED_ORIGINS,
+    ];
 
     // Setup window mocks
     global.window = Object.create(window);
@@ -27,6 +78,12 @@ describe('IntersendSdkClient', () => {
       configurable: true,
       value: mockAddEventListener,
     });
+    // The connector talks to window.parent; point it at the mocked window so
+    // outbound postMessage calls are observable.
+    Object.defineProperty(global.window, 'parent', {
+      configurable: true,
+      value: global.window,
+    });
 
     Object.defineProperty(global.window, 'crypto', {
       configurable: true,
@@ -34,10 +91,14 @@ describe('IntersendSdkClient', () => {
         randomUUID: jest.fn().mockReturnValue('123'),
       },
     });
+
+    // Default: register handlers without injecting a connect response.
+    mockAddEventListener.mockImplementation((event, handler) => {
+      if (event === 'message') messageHandlers.push(handler);
+    });
   });
 
   afterEach(() => {
-    // Clean up
     jest.resetAllMocks();
   });
 
@@ -49,26 +110,13 @@ describe('IntersendSdkClient', () => {
 
   describe('init', () => {
     it('should only initialize once', async () => {
-      const mockInfo = {
-        address: '0x123',
-        chainId: 1,
-      };
-
-      mockAddEventListener.mockImplementation((event, handler) => {
-        if (event === 'message') {
-          // @ts-expect-error - Event handler type is complex
-          handler({
-            data: {
-              type: 'INTERSEND_CONNECT_RESPONSE',
-              payload: mockInfo,
-            },
-          });
-        }
-      });
+      const mockInfo = { address: '0x123', chainId: 1 };
+      setupConnectResponse(mockInfo);
 
       await IntersendSdkClient.init();
       expect(IntersendSdkClient.isInitialized).toBe(true);
       expect(IntersendSdkClient.intersendInfo).toEqual(mockInfo);
+      expect(IntersendSdkClient.walletOrigin).toBe(ALLOWED_ORIGIN);
       expect(mockAddEventListener).toHaveBeenCalledTimes(2);
 
       // Second init should not reinitialize
@@ -78,14 +126,78 @@ describe('IntersendSdkClient', () => {
 
     it('should handle timeout when info is not received', async () => {
       jest.useFakeTimers();
-      
+
       const initPromise = IntersendSdkClient.init();
       jest.advanceTimersByTime(1000);
-      
+
       await initPromise;
       expect(IntersendSdkClient.intersendInfo).toBeUndefined();
-      
+      expect(IntersendSdkClient.walletOrigin).toBeUndefined();
+
       jest.useRealTimers();
+    });
+
+    it('sends connect requests pinned to allowed origins and never uses "*"', async () => {
+      setupConnectResponse({ address: '0x123', chainId: 1 });
+
+      await IntersendSdkClient.init();
+
+      const connectCalls = mockPostMessage.mock.calls.filter(
+        ([msg]) => msg?.type === 'INTERSEND_CONNECT_REQUEST',
+      );
+      expect(connectCalls.length).toBe(DEFAULT_INTERSEND_ALLOWED_ORIGINS.length);
+      for (const [, targetOrigin] of connectCalls) {
+        expect(targetOrigin).not.toBe('*');
+        expect(DEFAULT_INTERSEND_ALLOWED_ORIGINS).toContain(targetOrigin);
+      }
+    });
+
+    it('rejects a connect response from an untrusted origin', async () => {
+      jest.useFakeTimers();
+      setupConnectResponse(
+        { address: '0xAttacker', chainId: 137 },
+        { origin: UNTRUSTED_ORIGIN },
+      );
+
+      const initPromise = IntersendSdkClient.init();
+      jest.advanceTimersByTime(1000);
+      await initPromise;
+
+      expect(IntersendSdkClient.intersendInfo).toBeUndefined();
+      expect(IntersendSdkClient.walletOrigin).toBeUndefined();
+      jest.useRealTimers();
+    });
+
+    it('rejects a connect response with a mismatched requestId', async () => {
+      jest.useFakeTimers();
+      setupConnectResponse(
+        { address: '0xAttacker', chainId: 137 },
+        { requestId: 'not-the-real-id' },
+      );
+
+      const initPromise = IntersendSdkClient.init();
+      jest.advanceTimersByTime(1000);
+      await initPromise;
+
+      expect(IntersendSdkClient.intersendInfo).toBeUndefined();
+      expect(IntersendSdkClient.walletOrigin).toBeUndefined();
+      jest.useRealTimers();
+    });
+
+    it('honors a custom allowedOrigins allowlist', async () => {
+      const customOrigin = 'https://wallet.custom.example';
+      setupConnectResponse(
+        { address: '0x123', chainId: 1 },
+        { origin: customOrigin },
+      );
+
+      await IntersendSdkClient.init({ allowedOrigins: [customOrigin] });
+
+      expect(IntersendSdkClient.walletOrigin).toBe(customOrigin);
+      const connectCalls = mockPostMessage.mock.calls.filter(
+        ([msg]) => msg?.type === 'INTERSEND_CONNECT_REQUEST',
+      );
+      expect(connectCalls.map(([, target]) => target)).toEqual([customOrigin]);
     });
   });
 
@@ -96,10 +208,7 @@ describe('IntersendSdkClient', () => {
     });
 
     it('should return address when info is available', () => {
-      IntersendSdkClient.intersendInfo = {
-        address: '0x123',
-        chainId: 1,
-      };
+      IntersendSdkClient.intersendInfo = { address: '0x123', chainId: 1 };
       expect(IntersendSdkClient.getAddress()).toBe('0x123');
     });
   });
@@ -113,24 +222,10 @@ describe('IntersendSdkClient', () => {
   });
 
   describe('provider methods', () => {
+    const mockInfo = { address: '0x123', chainId: 1 };
+
     beforeEach(async () => {
-      const mockInfo = {
-        address: '0x123',
-        chainId: 1,
-      };
-
-      mockAddEventListener.mockImplementation((event, handler) => {
-        if (event === 'message') {
-          // @ts-expect-error - Event handler type is complex
-          handler({
-            data: {
-              type: 'INTERSEND_CONNECT_RESPONSE',
-              payload: mockInfo,
-            },
-          });
-        }
-      });
-
+      setupConnectResponse(mockInfo);
       await IntersendSdkClient.init();
     });
 
@@ -155,11 +250,65 @@ describe('IntersendSdkClient', () => {
     it('should throw error for unsupported methods', async () => {
       const provider = IntersendSdkClient.getProvider();
       await expect(
-        provider.request({
-          method: 'unsupported_method',
-          params: [],
-        })
+        provider.request({ method: 'unsupported_method', params: [] }),
       ).rejects.toThrow('Unsupported method: unsupported_method');
+    });
+
+    it('pins outbound sign requests to the verified wallet origin and resolves on a matching response', async () => {
+      const provider = IntersendSdkClient.getProvider();
+      const resultPromise = provider.request({
+        method: 'personal_sign',
+        params: ['hello'],
+      });
+
+      const signCall = mockPostMessage.mock.calls.find(
+        ([msg]) => msg?.type === 'SIGN_MESSAGE_REQUEST',
+      );
+      expect(signCall).toBeDefined();
+      expect(signCall![1]).toBe(ALLOWED_ORIGIN);
+      expect(signCall![1]).not.toBe('*');
+
+      const handleMessage = messageHandlers[0];
+      handleMessage({
+        origin: ALLOWED_ORIGIN,
+        data: {
+          type: 'SIGN_MESSAGE_RESPONSE',
+          requestId: signCall![0].requestId,
+          payload: '0xsignature',
+        },
+      });
+
+      await expect(resultPromise).resolves.toBe('0xsignature');
+    });
+
+    it('ignores a response injected from a non-wallet origin', async () => {
+      const provider = IntersendSdkClient.getProvider();
+      const resultPromise = provider.request({
+        method: 'eth_sendTransaction',
+        params: [{ to: '0xabc' }],
+      });
+
+      const txCall = mockPostMessage.mock.calls.find(
+        ([msg]) => msg?.type === 'TRANSACTION_REQUEST',
+      );
+      expect(txCall).toBeDefined();
+
+      const handleMessage = messageHandlers[0];
+      handleMessage({
+        origin: UNTRUSTED_ORIGIN,
+        data: {
+          type: 'TRANSACTION_RESPONSE',
+          requestId: txCall![0].requestId,
+          payload: '0xFORGED_BY_ATTACKER',
+        },
+      });
+
+      let settled = false;
+      void resultPromise.then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      expect(settled).toBe(false);
     });
   });
 });

--- a/packages/@dynamic-labs-connectors/intersend-evm/src/IntersendSdkClient.ts
+++ b/packages/@dynamic-labs-connectors/intersend-evm/src/IntersendSdkClient.ts
@@ -9,6 +9,20 @@ interface IntersendInfo {
   chainId: number;
 }
 
+/**
+ * Origins of the Interspace (Intersend) wallet host that is allowed to embed
+ * the dapp and exchange `postMessage` traffic with this connector.
+ *
+ * Every outbound message is pinned to one of these origins (never `'*'`) and
+ * every inbound message whose `event.origin` is not the verified wallet origin
+ * is dropped. Override at runtime via `IntersendSdkClient.init({ allowedOrigins })`
+ * if the wallet host is served from a different origin.
+ */
+export const DEFAULT_INTERSEND_ALLOWED_ORIGINS = [
+  'https://app.intersend.io',
+  'https://app.interspace.fi',
+];
+
 // Create a proper provider type that extends IEthereum
 class IntersendProvider extends EventEmitter {
   public readonly isIntersend = true;
@@ -35,22 +49,22 @@ class IntersendProvider extends EventEmitter {
       case 'eth_sendTransaction':
         return new Promise((resolve) => {
           IntersendSdkClient.setPendingRequest(requestId, resolve);
-          window.parent.postMessage({
+          IntersendSdkClient.postToWallet({
             type: 'TRANSACTION_REQUEST',
             payload: { params: methodParams[0] },
             requestId
-          }, '*');
+          });
         });
 
       case 'personal_sign':
       case 'eth_sign':
         return new Promise((resolve) => {
           IntersendSdkClient.setPendingRequest(requestId, resolve);
-          window.parent.postMessage({
+          IntersendSdkClient.postToWallet({
             type: 'SIGN_MESSAGE_REQUEST',
             payload: { message: methodParams[0] },
             requestId
-          }, '*');
+          });
         });
 
       default:
@@ -64,36 +78,88 @@ export class IntersendSdkClient {
   static provider: IntersendProvider;
   static walletClient: WalletClient;
   static intersendInfo: IntersendInfo | undefined;
+  /**
+   * Origin of the wallet host verified during the connect handshake. Outbound
+   * messages are pinned to it and inbound messages from any other origin are
+   * rejected. Stays `undefined` until a trusted host answers the connect
+   * request, so nothing is trusted before the handshake completes.
+   */
+  static walletOrigin: string | undefined;
+  private static allowedOrigins: string[] = DEFAULT_INTERSEND_ALLOWED_ORIGINS;
   private static pendingRequests = new Map<string, (value: any) => void>();
+
+  private static isAllowedOrigin = (origin: string): boolean =>
+    IntersendSdkClient.allowedOrigins.includes(origin);
+
+  /**
+   * Sends a message to the wallet host, pinned to the origin verified during
+   * the connect handshake. Drops the message if no trusted origin is known.
+   */
+  static postToWallet = (message: Record<string, unknown>): void => {
+    const targetOrigin = IntersendSdkClient.walletOrigin;
+    if (!targetOrigin) {
+      logger.debug(
+        '[IntersendSdkClient] no verified wallet origin; dropping message',
+      );
+      return;
+    }
+    window.parent.postMessage(message, targetOrigin);
+  };
 
   private constructor() {
     throw new Error('IntersendSdkClient is not instantiable');
   }
 
-  static init = async () => {
+  static init = async (options?: { allowedOrigins?: string[] }) => {
     if (IntersendSdkClient.isInitialized) {
       return;
     }
 
     IntersendSdkClient.isInitialized = true;
+    if (options?.allowedOrigins?.length) {
+      IntersendSdkClient.allowedOrigins = options.allowedOrigins;
+    }
     logger.debug('[IntersendSdkClient] initializing sdk');
 
     // Setup message listener for communication with parent frame
     window.addEventListener('message', IntersendSdkClient.handleMessage);
 
-    // Request initial connection info from parent
-    window.parent.postMessage({ type: 'INTERSEND_CONNECT_REQUEST' }, '*');
+    // Bind the connect handshake to a per-init id so a connect response cannot
+    // be injected out of band.
+    const connectRequestId = `${Date.now()}-${Math.random()}`;
+
+    // Request initial connection info from the parent. Pin each request to a
+    // trusted origin: the browser only delivers a message to the parent when
+    // its origin matches the targetOrigin, so an untrusted embedder never
+    // receives the request and cannot answer it.
+    for (const origin of IntersendSdkClient.allowedOrigins) {
+      window.parent.postMessage(
+        { type: 'INTERSEND_CONNECT_REQUEST', requestId: connectRequestId },
+        origin,
+      );
+    }
 
     // Wait for connection response
     IntersendSdkClient.intersendInfo = await new Promise((resolve) => {
       const timeout = setTimeout(() => resolve(undefined), 1000);
       
       const handler = (event: MessageEvent) => {
-        if (event.data.type === 'INTERSEND_CONNECT_RESPONSE') {
-          clearTimeout(timeout);
-          window.removeEventListener('message', handler);
-          resolve(event.data.payload);
+        // Only trust a connect response from an allowed origin that echoes the
+        // id we just issued.
+        if (!IntersendSdkClient.isAllowedOrigin(event.origin)) {
+          return;
         }
+        if (event.data?.type !== 'INTERSEND_CONNECT_RESPONSE') {
+          return;
+        }
+        if (event.data?.requestId !== connectRequestId) {
+          return;
+        }
+
+        clearTimeout(timeout);
+        window.removeEventListener('message', handler);
+        IntersendSdkClient.walletOrigin = event.origin;
+        resolve(event.data.payload);
       };
 
       window.addEventListener('message', handler);
@@ -122,7 +188,16 @@ export class IntersendSdkClient {
   };
 
   private static handleMessage = (event: MessageEvent) => {
-    const { type, payload, requestId } = event.data;
+    // Reject any message that is not from the wallet host verified during the
+    // connect handshake.
+    if (
+      !IntersendSdkClient.walletOrigin ||
+      event.origin !== IntersendSdkClient.walletOrigin
+    ) {
+      return;
+    }
+
+    const { type, payload, requestId } = event.data ?? {};
     
     switch (type) {
       case 'TRANSACTION_RESPONSE':


### PR DESCRIPTION
## Summary

Fixes a missing-origin-validation bug (CWE-346 / CWE-940) in `@dynamic-labs-connectors/intersend-evm`, reported via HackerOne #3771339. The connector talks to its wallet host over `window.parent.postMessage` but pinned every outbound message to `'*'` and read every inbound message with **no `event.origin` check**. Because the connector only loads when framed (`isInIframe()`) and auto-connects, any page that embeds a victim dapp using this connector could spoof the connected wallet address, read the SIWE message/nonce the dapp emits, and inject forged signature/transaction responses (login-CSRF / session-fixation risk).

The fix mirrors the pattern already used by the sibling Sequence connector (`ProviderTransport.ts` validates `event.origin !== this.walletOrigin` and pins `targetOrigin`).

### What changed (`IntersendSdkClient.ts`)

- **Origin allowlist.** Added `DEFAULT_INTERSEND_ALLOWED_ORIGINS = ['https://app.intersend.io', 'https://app.interspace.fi']`, overridable via `init({ allowedOrigins })`.
- **Outbound pinning.** No message is ever sent with `'*'`:
  - The connect handshake posts to each allowed origin explicitly (the browser only delivers to the parent if its origin matches, so untrusted embedders never receive the request).
  - tx/sign requests go through `postToWallet(...)`, pinned to the `walletOrigin` verified during connect; if no trusted origin was verified the message is dropped.
- **Inbound validation.**
  - Connect handler now requires `isAllowedOrigin(event.origin)` **and** a matching `requestId` (a per-`init` nonce) before accepting `INTERSEND_CONNECT_RESPONSE`. On success it records `walletOrigin = event.origin`.
  - `handleMessage` rejects anything whose `event.origin !== walletOrigin`, so forged `TRANSACTION_RESPONSE` / `SIGN_MESSAGE_RESPONSE` from other origins are ignored.

```ts
// before
window.parent.postMessage({ type: 'INTERSEND_CONNECT_REQUEST' }, '*');
const handler = (event) => { if (event.data.type === 'INTERSEND_CONNECT_RESPONSE') resolve(event.data.payload); };
private static handleMessage = (event) => { const { type, payload, requestId } = event.data; /* no origin gate */ };

// after
for (const origin of allowedOrigins) window.parent.postMessage({ type: 'INTERSEND_CONNECT_REQUEST', requestId: connectRequestId }, origin);
const handler = (event) => {
  if (!isAllowedOrigin(event.origin)) return;
  if (event.data?.type !== 'INTERSEND_CONNECT_RESPONSE' || event.data?.requestId !== connectRequestId) return;
  walletOrigin = event.origin; resolve(event.data.payload);
};
private static handleMessage = (event) => { if (!walletOrigin || event.origin !== walletOrigin) return; /* ... */ };
```

### Tests

`IntersendSdkClient.spec.ts` extended (9 → 15 tests): connect requests are pinned (never `'*'`), connect responses from an untrusted origin or with a mismatched `requestId` are rejected, a custom `allowedOrigins` allowlist is honored, outbound sign/tx requests are pinned to the verified origin, and a response injected from a non-wallet origin is ignored.

### Action needed from reviewers

`DEFAULT_INTERSEND_ALLOWED_ORIGINS` is a best-effort default derived from Intersend/Interspace's public docs. **Please confirm the canonical Intersend wallet-host origin(s)** and adjust the constant if needed — if they don't match production, auto-connect will simply fail closed (degrades safely rather than insecurely) rather than trust an arbitrary parent.

### Note: separate CI-unblock commit

A first commit (`ci: exclude non-workspace playground app from nx project graph`) adds a `.nxignore` for `playground`. `main` CI has been red since the playground app was added (PR #135): `playground/` is not in the pnpm workspace, so its `eslint-config-next` dep is never installed and `nx affected` fails to build the project graph (which also blocks the pre-commit hook). Ignoring the non-workspace demo app restores the pre-playground graph behavior so this PR's lint/test/build can run. Happy to split this into its own PR if preferred.

Link to Devin session: https://app.devin.ai/sessions/f0bbf789fec241fc8409a1eeb0240e8c
Requested by: @paololim