### PR TITLE
Fix Sequence chain id normalization

### DIFF
--- a/packages/@dynamic-labs-connectors/sequence-cross-app-evm/src/utils.spec.ts
+++ b/packages/@dynamic-labs-connectors/sequence-cross-app-evm/src/utils.spec.ts
@@ -1,0 +1,24 @@
+import { normalizeChainId } from './utils.js';
+
+describe('normalizeChainId', () => {
+  it('should normalize decimal and hex chain ids', () => {
+    expect(normalizeChainId(1)).toBe(1);
+    expect(normalizeChainId(1n)).toBe(1);
+    expect(normalizeChainId('1')).toBe(1);
+    expect(normalizeChainId('0x1')).toBe(1);
+    expect(normalizeChainId({ chainId: '0x2105' })).toBe(8453);
+  });
+
+  it('should reject invalid string chain ids', () => {
+    expect(() => normalizeChainId('')).toThrow('Invalid chain id');
+    expect(() => normalizeChainId('abc')).toThrow('Invalid chain id');
+    expect(() => normalizeChainId('0x')).toThrow('Invalid chain id');
+    expect(() => normalizeChainId('1abc')).toThrow('Invalid chain id');
+  });
+
+  it('should reject unsafe bigint chain ids', () => {
+    expect(() => normalizeChainId(BigInt(Number.MAX_SAFE_INTEGER) + 1n)).toThrow(
+      'Invalid chain id',
+    );
+  });
+});

--- a/packages/@dynamic-labs-connectors/sequence-cross-app-evm/src/utils.ts
+++ b/packages/@dynamic-labs-connectors/sequence-cross-app-evm/src/utils.ts
@@ -4,14 +4,29 @@ export function normalizeChainId(
   if (typeof chainId === 'object') {
     return normalizeChainId(chainId.chainId);
   }
+
+  let normalizedChainId: number;
   if (typeof chainId === 'string') {
-    return Number.parseInt(
-      chainId,
-      chainId.trim().substring(0, 2) === '0x' ? 16 : 10,
-    );
+    const trimmed = chainId.trim();
+    const isHex = trimmed.startsWith('0x');
+
+    if (isHex ? !/^0x[\da-f]+$/iu.test(trimmed) : !/^\d+$/u.test(trimmed)) {
+      throw new Error(`Invalid chain id: ${chainId}`);
+    }
+
+    normalizedChainId = Number.parseInt(trimmed, isHex ? 16 : 10);
+  } else if (typeof chainId === 'bigint') {
+    if (chainId < 0n || chainId > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw new Error(`Invalid chain id: ${chainId.toString()}`);
+    }
+    normalizedChainId = Number(chainId);
+  } else {
+    normalizedChainId = chainId;
   }
-  if (typeof chainId === 'bigint') {
-    return Number(chainId);
+
+  if (!Number.isSafeInteger(normalizedChainId) || normalizedChainId < 0) {
+    throw new Error(`Invalid chain id: ${chainId.toString()}`);
   }
-  return chainId;
+
+  return normalizedChainId;
 }


### PR DESCRIPTION
Fixes Sequence chain id normalization so invalid string inputs are rejected instead of being partially parsed or returning NaN. Also guards bigint/number inputs against unsafe values and adds focused coverage for decimal, hex, nested, invalid, and unsafe chain ids.