### PR TITLE
feat: add MOSS Wallet EVM connector

### DIFF
--- a/packages/@dynamic-labs-connectors/moss-evm/.swcrc
+++ b/packages/@dynamic-labs-connectors/moss-evm/.swcrc
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://swc.rs/schema.json",
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    },
+    "keepClassNames": true,
+    "externalHelpers": false,
+    "loose": true,
+    "minify": {}
+  },
+  "module": {
+    "type": "es6"
+  },
+  "sourceMaps": false,
+  "exclude": [
+    "jest.config.ts",
+    ".*\\.spec.tsx?$",
+    ".*\\.test.tsx?$",
+    "./src/jest-setup.ts$",
+    "./**/jest-setup.ts$",
+    ".*.cjs$",
+    ".*.js$"
+  ]
+}

--- a/packages/@dynamic-labs-connectors/moss-evm/eslint.config.cjs
+++ b/packages/@dynamic-labs-connectors/moss-evm/eslint.config.cjs
@@ -1,0 +1,19 @@
+const baseConfig = require('../../../eslint.config.js');
+
+module.exports = [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs}'],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: require('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/packages/@dynamic-labs-connectors/moss-evm/jest.config.ts
+++ b/packages/@dynamic-labs-connectors/moss-evm/jest.config.ts
@@ -1,0 +1,29 @@
+/* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+export default {
+  displayName: '@dynamic-labs-connectors/moss-evm',
+  preset: '../../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
+  coverageDirectory:
+    '../../../coverage/packages/@dynamic-labs-connectors/moss-evm',
+  moduleNameMapper: {
+    '^@dynamic-labs-connectors/base-account-evm$': '<rootDir>/../../../jest-config/mocks/base-account-evm.js',
+  },
+};

--- a/packages/@dynamic-labs-connectors/moss-evm/package.json
+++ b/packages/@dynamic-labs-connectors/moss-evm/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@dynamic-labs-connectors/moss-evm",
+  "version": "4.6.9",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dynamic-labs-oss/public-wallet-connectors.git",
+    "directory": "packages/@dynamic-labs-connectors/moss-evm"
+  },
+  "type": "module",
+  "main": "./src/index.js",
+  "typings": "./src/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "private": false,
+  "exports": {
+    ".": {
+      "import": "./src/index.js",
+      "require": "./src/index.js",
+      "types": "./src/index.d.ts"
+    }
+  },
+  "dependencies": {
+    "@megaeth-labs/wallet-sdk": ">=0.1.19 <1.0.0"
+  },
+  "peerDependencies": {
+    "@dynamic-labs/ethereum-core": "^4.31.2",
+    "@dynamic-labs/ethereum": "^4.31.2",
+    "@dynamic-labs/wallet-connector-core": "^4.31.2",
+    "viem": "^2.21.55"
+  }
+}

--- a/packages/@dynamic-labs-connectors/moss-evm/project.json
+++ b/packages/@dynamic-labs-connectors/moss-evm/project.json
@@ -1,0 +1,19 @@
+{
+  "name": "@dynamic-labs-connectors/moss-evm",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/@dynamic-labs-connectors/moss-evm/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:swc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/@dynamic-labs-connectors/moss-evm",
+        "main": "packages/@dynamic-labs-connectors/moss-evm/src/index.ts",
+        "tsConfig": "packages/@dynamic-labs-connectors/moss-evm/tsconfig.lib.json",
+        "generateExportsField": true
+      }
+    }
+  }
+}

--- a/packages/@dynamic-labs-connectors/moss-evm/src/MossEvmWalletConnector.spec.ts
+++ b/packages/@dynamic-labs-connectors/moss-evm/src/MossEvmWalletConnector.spec.ts
@@ -1,0 +1,144 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { type EthereumWalletConnectorOpts } from '@dynamic-labs/ethereum-core';
+import { MossEvmWalletConnector } from './MossEvmWalletConnector.js';
+import { MossWalletSdkClient } from './MossWalletSdkClient.js';
+
+jest.mock('./MossWalletSdkClient.js');
+jest.mock('@dynamic-labs/wallet-connector-core', () => ({
+  ...jest.requireActual('@dynamic-labs/wallet-connector-core'),
+  logger: {
+    debug: jest.fn(),
+  },
+}));
+
+const walletConnectorProps: EthereumWalletConnectorOpts = {
+  walletBook: {} as any,
+  evmNetworks: [],
+} as any as EthereumWalletConnectorOpts;
+
+describe('MossEvmWalletConnector', () => {
+  let connector: MossEvmWalletConnector;
+  let emitSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    connector = new MossEvmWalletConnector(walletConnectorProps);
+    emitSpy = jest.spyOn(connector.walletConnectorEventsEmitter, 'emit');
+
+    (MossWalletSdkClient.getAddress as jest.Mock).mockResolvedValue('0x123');
+    (MossWalletSdkClient.isInitialized as any) = false;
+  });
+
+  it('should initialize with correct name', () => {
+    expect(connector.name).toBe('MOSS Wallet');
+  });
+
+  it('should set canConnectViaCustodialService to true', () => {
+    expect(connector.canConnectViaCustodialService).toBe(true);
+  });
+
+  describe('init', () => {
+    it('should initialize SDK and emit providerReady', async () => {
+      await connector.init();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(MossWalletSdkClient.init).toHaveBeenCalled();
+      expect(emitSpy).toHaveBeenCalledWith('providerReady', {
+        connector,
+        shouldAutoConnect: true,
+      });
+    });
+
+    it('should emit providerReady with shouldAutoConnect false when no address', async () => {
+      (MossWalletSdkClient.getAddress as jest.Mock).mockResolvedValue(undefined);
+      await connector.init();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(emitSpy).toHaveBeenCalledWith('providerReady', {
+        connector,
+        shouldAutoConnect: false,
+      });
+    });
+
+    it('should not re-initialize when already initialized', async () => {
+      (MossWalletSdkClient.isInitialized as any) = true;
+      await connector.init();
+
+      expect(MossWalletSdkClient.init).not.toHaveBeenCalled();
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('supportsNetworkSwitching', () => {
+    it('should return false', () => {
+      expect(connector.supportsNetworkSwitching()).toBe(false);
+    });
+  });
+
+  describe('findProvider', () => {
+    it('should return the provider from MossWalletSdkClient', () => {
+      const mockProvider = {} as any;
+      (MossWalletSdkClient.getProvider as jest.Mock).mockReturnValue(
+        mockProvider,
+      );
+
+      expect(connector.findProvider()).toBe(mockProvider);
+    });
+  });
+
+  describe('getAddress', () => {
+    it('should return the connected address', async () => {
+      expect(await connector.getAddress()).toBe('0x123');
+    });
+
+    it('should return undefined when not connected', async () => {
+      (MossWalletSdkClient.getAddress as jest.Mock).mockResolvedValue(undefined);
+      expect(await connector.getAddress()).toBeUndefined();
+    });
+  });
+
+  describe('getConnectedAccounts', () => {
+    it('should return empty array when no address', async () => {
+      (MossWalletSdkClient.getAddress as jest.Mock).mockResolvedValue(undefined);
+      expect(await connector.getConnectedAccounts()).toEqual([]);
+    });
+
+    it('should return accounts and set active account', async () => {
+      const setActiveAccountSpy = jest
+        .spyOn(connector, 'setActiveAccount')
+        .mockImplementation(() => undefined);
+
+      const accounts = await connector.getConnectedAccounts();
+
+      expect(accounts).toEqual(['0x123']);
+      expect(setActiveAccountSpy).toHaveBeenCalledWith('0x123');
+    });
+  });
+
+  describe('signMessage', () => {
+    it('should return undefined when no wallet client', async () => {
+      jest.spyOn(connector, 'getWalletClient').mockReturnValue(undefined);
+      expect(await connector.signMessage('Hello')).toBeUndefined();
+    });
+
+    it('should sign a message via wallet client', async () => {
+      jest.spyOn(connector, 'getWalletClient').mockReturnValue({
+        signMessage: jest.fn().mockResolvedValue('0xsig'),
+      } as any);
+
+      expect(await connector.signMessage('Hello')).toBe('0xsig');
+    });
+  });
+
+  describe('filter', () => {
+    it('should return true when provider is available', () => {
+      (MossWalletSdkClient.getProvider as jest.Mock).mockReturnValue({});
+      expect(connector.filter()).toBe(true);
+    });
+
+    it('should return false when provider is not available', () => {
+      (MossWalletSdkClient.getProvider as jest.Mock).mockReturnValue(undefined);
+      expect(connector.filter()).toBe(false);
+    });
+  });
+});

--- a/packages/@dynamic-labs-connectors/moss-evm/src/MossEvmWalletConnector.ts
+++ b/packages/@dynamic-labs-connectors/moss-evm/src/MossEvmWalletConnector.ts
@@ -1,0 +1,98 @@
+import { type Hex } from 'viem';
+
+import { logger } from '@dynamic-labs/wallet-connector-core';
+import { type EthereumWalletConnectorOpts } from '@dynamic-labs/ethereum-core';
+import { EthereumInjectedConnector, type IEthereum } from '@dynamic-labs/ethereum';
+
+import { MossWalletSdkClient } from './MossWalletSdkClient.js';
+
+const MOSS_ICON =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAhGVYSWZNTQAqAAAACAAFARIAAwAAAAEAAQAAARoABQAAAAEAAABKARsABQAAAAEAAABSASgAAwAAAAEAAgAAh2kABAAAAAEAAABaAAAAAAAAAEgAAAABAAAASAAAAAEAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAAAoDQEPAAAACXBIWXMAAAsTAAALEwEAmpwYAAABWWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNi4wLjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgoZXuEHAAANWElEQVRoBbVaaVBUVxY+3Q3ITgMGRFy6ZRNFhagkERfcZxJ0kqpsP2JApbJqXKYqmSWJbU1SlZo/QaOVpBJcZmJqamIGdSo6iZggEnFBaURFRGQxKrhgqygIdPec73bf16/bBhpNTlXz7rv33O3cc7+zPDT0K1BDZaXeGhL4tMamSddqNCN5yHTSkJ7s/HNRI2k0jTaiKj+7vdJms+03pqY2upofrKR5sG5EWLQ2NHSFzW7PtvOvp6eb2tvbqa3tBl25coVu3LBQR0cHr5nIz8+P9Ho9PfLIIzRkSCyFhYaJOp7bzL8CeojNDHgDWDjxwsluW2m32fX19fV0vNJMlWYz/XLhAt3lRfOGepVLSEgwbySGkpOSKGvKEzR2zFjS6rT8022xdXevHeipDGgDTbV1a2xkW9nZ2akvKyuj//2wl86fP9/rYn1pGDw4mubNm0vTp02nGD4h0mpNxqSktb70BY9PG2ioqTHwwEUs2vQztWdp+7fbWeJVXiUN6WtYbzAwJIuS1WZlLXGcCtq80YgRw+nF51+gzMmTeSpNIw8+05fT8D6aaoaGc7W5fDkL7ty5q9+8dSuVlJSQ1WpVcUBoWjIaDTR+/DhKGJXAej6EoqOjKSgoUPB1d/eQxWKhy5cv05kzZ6juXD1B9e7eves2job3mJk5mfLycil2SKyFQWCxMSVlhxuTx0ufG2iqq1tjtdlM5+sb6JMNG6j5QrNb98GDB9P06dNpKutyXFwcDRo0SNUOiXsfnhGIrl67RuUHD1Lxvh+phTfG6OQg7hYWHkb5S5fQtKlTIRzTyD5UyvsMPBQWzxOZzp07Rx999Hdqs9xQJvDz0/HCp9FLL71E+ogI58wP9rh9+zbt4038Z0eRQDG56eDgIMpd9DLNnTuHj5j4XqSs9TaD1w001NY+zcxFJ6qracMnG+haW5vSN47VIy83lyZOfFSojtLwkIVfLl6kgoJ1dL6hQRkpMDCQ/rhqJc81ESiVNzIxcavS6CzctwFxYXW6yuamC/q/ffABXW+77mS1U3r6BHpr2XKB6Z4D/RrvfM+ocFMhlewvVYYLCQ6m5W8tx+W28OXL8LzY92+gtrahq6vL8PY7f1bpvJ2mTZtGy998UxogOn78OLXdcKqVczo/nY6yWG/92XB5I9yKYxUVZLl5060ZIJA1ZYq4Qz09PfTN9m9p165ddK+rS/AF8t368MMPyGAwmEelpGSoO7vN1FRbyzhPhm8YJtUXNikxgZYszlMWjwGKduykU6dPq8cS7caEUTRy+Ai3evnS3d1FBevXEyStptDQUIFggQGDxBgvvvC8QK29xcWCrfPePdr6j3/SX955J72+rtaUkJRikv21sgDV4cWbGhsb6fvvf5DVDIdRtGrVaooI7/+yQnoHfz7ImK9gijIOCpVssQGdwk6wPXA9uRHH4yTU5768iNLGjpFVdOLECdpfdoB0ds2KSngDTlI2wDfSBHz/atvXjAZ3RHOAvz/l5y+lIbGxkr/fZ3n5ISea3M+KNoky6lZvrkcw6/4br79OcD0k7WS1utPerg8NDlwp68QGIH2+DLknqk/SMdZtScD4zEmT5atPz4uXLlHt2bP38cLRq2Ej5o16s84wiAtzFoiTQr/Lly7T93uLyY+0K4RPxnXyBLLZq6Ti4r0KMyQwf/485d3bxLIOEmQ3WryifOjQYdmkPOvZZ7p+XSKaw0NVGvsowA5ER0UJDox9gH0wm92mt4UGi1MQG9BotSvaGOtxApLGj4NbMEq+9vtMSk5WeMxVZmq/0668o3DkyBHFBQG+GwwGpZ3X1SvBDc/JeUppb2pqYgeygbR2+wxUasXlZSetglXnzh2H7qPhyd//Dg+fCMLPynpCOQWL5SYdP1ap9MXFrWD4lKqSlTWFAgcFKO3Ow1PePQtz58wh2AMQu/C0r3gfLn22iEms/rpsDAAnSxKcsJSUFPnq03PSxEkUGhYmeHHURyuOKv0c6uOw5jr2UB9/7DE16Ch8vRWCgoJc6+G1VlVVERxEa0jI01pNjy29m6Ops+wmSxqbNpb8GYEGQnp9BI1WbRqGTp6omYMd3DGQ0WigJA5m1GjUlwoxo6C0cWmySJZbt6ilpYV0HLqyEdROQPgHp0pSavLApC/7wVpL6ui8R9Unq+kGO4HlhwCfDsJJhYeFylfx7E+FwJSSnKT4XhxQ0SVGO7vNZvDjwMFw6+YtQqWkuLihsjig5zg+uUi+dDfY9wcBMXp6rBwHtAj9xx2YwdD8IBQdPZjjiyDlVC/xmBA+UMgAjJZBCiYJZ3/8QSg8PJzSM9KVrqeqT9NevnDy8gLVYoVRZEVWkS8qhEscEOC6+Fgz3zW9gNF77GtIJNOxQxbAztODEi6oDGxutd+mUydd0IwYwkFyNsebLyqExcNZlOTUGMcGgBqSIC13+cgW354ZGRk0fNgwhVle3kG8gPR0N0dS4fG5oNopVoxXnIBFfTRQJXanfR7TkxFSmsIhpiclJibS0Lghzmp3EQn5uVd5dmfY7Ob71KPUBzPUQzhiA9Bd6cPDk7zp4a8rvXwsTJo0ieAIqgnBOvx+B7lOHO8qwTrb739A57tY1SWFC5ujaeSMEplhrgNUlhEO2cMQws4MvsyRkZEUxX4M8j2TOCzsk9z3dB8rgifEBSCofAyDgcZub/SzWe1NERyYh4WFK4EGLOfDEIBg+bJlYgjcKZxqSEiIakh3fVFdQRWPe7G5uUlBSoBEbAy7+FptldautZthdRM56pJ0kp06tb7Jes8nJ6DYxCfRn95+m5HHkQOSPPBm8QN2uy/ewbGag/WFCxawxUdQ2I/4mQOJNEHMCvWJjY0hKyeJ/XT+gTv41m5OSUmmsrKfBU87O3Vn2acfM8YVETl6u/4iUnv91dcoO3sGQeIDJRg8RF2A1t3f7emzO2C+mjMkkiZwAg1pFySFtUaj0cK3qORRhjiJ32BEZqC30BDtUJHZs2cpiwd6XeTUCEx8j9WFFuCVdIt9mAucAMaCQFCvUUYjLVv2BiFJZnfXLNmNSktLORTtcLwzz/z589HbjAyFI6i3W/ezhcwel5ZGFccq0CjcgAU5OTR8uAvTlRG5oJY6Bxi0YeNGOnT4sKifN3cuvbxokZqdysvL6YvCQrGQkZwHfffdv4o0uxuTlxdkMIp27lJaYGNY6IDPAlQ6cC0gsIAhzjJjhrSUJKS0e89upWNfhdbWK1R64AD36RIL3Pfjj5xycSXDgBqIZxEnwMYgN3r0KATVPx1mR7C1tVVhnD17thASa8d+VIoN8I7gfa3LzMyk1NGpCnNpaRnHCbXKe28FqI/69DmfypjtbgytHmolIbG3MVGPDyX/+vc3AjbxHhMTQ1M5GOIdbJEJLmlZiD2lAn8/f0v+0qVOZCDq6Oygjws+ppbWFvTvleKHDqXsmTMdpp2N1TyOoIDTkqDrCxf+QUGcYcPixfcA2e7tiaTWF18Wuowqo08Oq3RUVDQF6nRrZR+14KihtsZkt2vWfPX1Nioq2il5RH7m/ffec0tsKY3OAoDw6tWrwqLDMGLRnoSYA6qFTHaAv8uz9OQDeHy1bRvtkLrPg+OLjsn0PjzStQmpqSbZx3UCXGNMSTVxgG9GKiMulv0WrIrpdE0NffrZZ32iEpYLiwvr623xGCeM8XvkiJH9Lh6JtV27/osugmArFi/Oo6DAwEb14tHotgHBbbU+w5bZsnr1KoqICBebwNeVn0pKaOOnnxKg8LcigMDmLVuosHCTEoIi+F+5cgUbzGQLR2AzPee+/5yZgzMVeWymNx8+fITWrVtPnV0uJyqBISw/Px8Deo71UO+wH4WbNrksLo8GD+G1V1+hWdnZUIZnvH2t8boBrKS+psbEqrAGOcn1n2zkz6aciXZyw+At4FwNXAEkZh+G4CYfYAhGSlOdtcZUS5YspqeefBKq66b36vl63QCY+CRMfBJrqqtP0eeff06XWuClyi7sEbLOI+k08dGJAuLUxk1Mgjsk2eWF4grYBagickXf7d5Dzc3NisqALYIzHC88/xzNmTULHzZ6XTzmUIYXE3r5I77WaDSbr7S26r8s/JK/C7hSJJIdTlsSByxpbMlHj04huNPh7OH6Of3/HkYVJLfwLQwf986crePcjpk3cVsOIZ5YTGJCIr3ySj4lJCbCNq0yJidvEY29/Ol3A+iH7B2fxE8sOUNFxTH+ALFdfAoC3PVG+DoPTxSE7wK4oJC8N0J9VFQkPffsszR75izyD/BnKdmekcbKWx9Z59MGJLNUKXwyLWFU+m7PHk7YulwGyTeQZ2hoCKclsyiHdT0+Pt7CC1/HCzf5OsaANoBBnaeBCXLhQuBfDI6wX1PH7jeyZfcYsSBoT1sAKcO24Z5E6iMpNTWVHns8k9LHT0DcIBbOyakCY0YGVMdnGvAG5MhiI0TZrForuC4daHLt+jXxMfvq1WsilS6TAzqdHxs4vbjo8fFD2b5EcLI2hNholhB7wnR34AuX63jgDcgB8MRmrLwZlno6W8YJXGVgcRv46SCNBhJG3GHmTEITn4ZZ19m5Y6DSlsOpn/8HoJdadFJ3DXkAAAAASUVORK5CYII=';
+
+export class MossEvmWalletConnector extends EthereumInjectedConnector {
+  override name = 'MOSS Wallet';
+
+  override canConnectViaCustodialService = true;
+
+  constructor(props: EthereumWalletConnectorOpts) {
+    super({
+      ...props,
+      metadata: {
+        id: 'mossWallet',
+        name: 'MOSS Wallet',
+        icon: MOSS_ICON,
+      },
+    });
+  }
+
+  override async init(): Promise<void> {
+    if (MossWalletSdkClient.isInitialized) {
+      return;
+    }
+
+    await MossWalletSdkClient.init();
+    this.onProviderReady();
+  }
+
+  private onProviderReady = async (): Promise<void> => {
+    logger.debug('[MossEvmWalletConnector] onProviderReady');
+
+    this.walletConnectorEventsEmitter.emit('providerReady', {
+      connector: this,
+      shouldAutoConnect: await this.shouldAutoConnect(),
+    });
+  };
+
+  private async shouldAutoConnect(): Promise<boolean> {
+    const address = await this.getAddress();
+
+    logger.debug(
+      '[MossEvmWalletConnector] shouldAutoConnect - address:',
+      address,
+    );
+
+    return Boolean(address);
+  }
+
+  override supportsNetworkSwitching(): boolean {
+    return false;
+  }
+
+  override findProvider(): IEthereum | undefined {
+    return MossWalletSdkClient.getProvider();
+  }
+
+  override async getAddress(): Promise<string | undefined> {
+    return MossWalletSdkClient.getAddress();
+  }
+
+  override async getConnectedAccounts(): Promise<string[]> {
+    const account = await this.getAddress();
+
+    if (!account) {
+      return [];
+    }
+
+    this.setActiveAccount(account as Hex);
+
+    return [account];
+  }
+
+  override async signMessage(
+    messageToSign: string,
+  ): Promise<string | undefined> {
+    const client = this.getWalletClient();
+
+    if (!client) {
+      return undefined;
+    }
+
+    return client.signMessage({
+      message: messageToSign,
+    });
+  }
+
+  override filter(): boolean {
+    return Boolean(MossWalletSdkClient.getProvider());
+  }
+}

--- a/packages/@dynamic-labs-connectors/moss-evm/src/MossWalletSdkClient.spec.ts
+++ b/packages/@dynamic-labs-connectors/moss-evm/src/MossWalletSdkClient.spec.ts
@@ -1,0 +1,316 @@
+import { mega } from '@megaeth-labs/wallet-sdk';
+import { MossWalletSdkClient } from './MossWalletSdkClient.js';
+
+jest.mock('@megaeth-labs/wallet-sdk', () => ({
+  mega: {
+    initialise: jest.fn(),
+    status: jest.fn(),
+    connect: jest.fn(),
+    signMessage: jest.fn(),
+    signData: jest.fn(),
+    callContract: jest.fn(),
+    events: {
+      onStatusChange: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('viem/chains', () => ({
+  megaeth: { id: 6342 },
+  megaethTestnet: { id: 954305 },
+}));
+
+jest.mock('viem', () => ({
+  hexToString: jest.fn((hex: string) =>
+    Buffer.from(hex.replace('0x', ''), 'hex').toString('utf-8'),
+  ),
+  isAddress: jest.fn((value: string) => /^0x[0-9a-fA-F]{40}$/.test(value)),
+  isHex: jest.fn((value: string) => /^0x/.test(value)),
+}));
+
+jest.mock('@dynamic-labs/wallet-connector-core', () => ({
+  logger: { debug: jest.fn() },
+}));
+
+const connectedStatus = {
+  status: 'connected' as const,
+  address: '0xabc123' as `0x${string}`,
+  network: 'mainnet' as const,
+};
+
+const disconnectedStatus = {
+  status: 'disconnected' as const,
+  network: 'mainnet' as const,
+};
+
+describe('MossWalletSdkClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MossWalletSdkClient.isInitialized = false;
+    MossWalletSdkClient.provider = undefined;
+  });
+
+  describe('constructor', () => {
+    it('should not be instantiable', () => {
+      // @ts-expect-error testing private constructor
+      expect(() => new MossWalletSdkClient()).toThrow();
+    });
+  });
+
+  describe('init', () => {
+    it('should only initialize once', async () => {
+      (mega.initialise as jest.Mock).mockResolvedValue(connectedStatus);
+
+      await MossWalletSdkClient.init();
+      await MossWalletSdkClient.init();
+
+      expect(mega.initialise).toHaveBeenCalledTimes(1);
+    });
+
+    it('should initialize provider with mainnet chain id when network is mainnet', async () => {
+      (mega.initialise as jest.Mock).mockResolvedValue(connectedStatus);
+
+      await MossWalletSdkClient.init();
+
+      expect(MossWalletSdkClient.provider).toBeDefined();
+      const chainId = await MossWalletSdkClient.provider!.request({
+        method: 'eth_chainId',
+      });
+      expect(chainId).toBe(`0x${(6342).toString(16)}`);
+    });
+
+    it('should fall back to mega.status() when initialise returns undefined', async () => {
+      (mega.initialise as jest.Mock).mockResolvedValue(undefined);
+      (mega.status as jest.Mock).mockResolvedValue(disconnectedStatus);
+
+      await MossWalletSdkClient.init();
+
+      expect(mega.status).toHaveBeenCalled();
+    });
+
+    it('should subscribe to status changes', async () => {
+      (mega.initialise as jest.Mock).mockResolvedValue(connectedStatus);
+
+      await MossWalletSdkClient.init();
+
+      expect(mega.events.onStatusChange).toHaveBeenCalled();
+    });
+
+    it('should set provider account from initial connected status', async () => {
+      (mega.initialise as jest.Mock).mockResolvedValue(connectedStatus);
+
+      await MossWalletSdkClient.init();
+
+      const accounts = (await MossWalletSdkClient.provider!.request({
+        method: 'eth_accounts',
+      })) as string[];
+      expect(accounts).toEqual(['0xabc123']);
+    });
+  });
+
+  describe('getAddress', () => {
+    it('should return undefined when provider is not initialized', async () => {
+      expect(await MossWalletSdkClient.getAddress()).toBeUndefined();
+    });
+
+    it('should return the connected address', async () => {
+      (mega.initialise as jest.Mock).mockResolvedValue(connectedStatus);
+      await MossWalletSdkClient.init();
+
+      expect(await MossWalletSdkClient.getAddress()).toBe('0xabc123');
+    });
+
+    it('should return undefined when disconnected', async () => {
+      (mega.initialise as jest.Mock).mockResolvedValue(disconnectedStatus);
+      await MossWalletSdkClient.init();
+
+      expect(await MossWalletSdkClient.getAddress()).toBeUndefined();
+    });
+  });
+
+  describe('getProvider', () => {
+    it('should return undefined when not initialized', () => {
+      expect(MossWalletSdkClient.getProvider()).toBeUndefined();
+    });
+
+    it('should return the provider after initialization', async () => {
+      (mega.initialise as jest.Mock).mockResolvedValue(connectedStatus);
+      await MossWalletSdkClient.init();
+
+      expect(MossWalletSdkClient.getProvider()).toBeDefined();
+    });
+  });
+});
+
+describe('MossEip1193Provider (via MossWalletSdkClient)', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    MossWalletSdkClient.isInitialized = false;
+    MossWalletSdkClient.provider = undefined;
+
+    (mega.initialise as jest.Mock).mockResolvedValue(connectedStatus);
+    await MossWalletSdkClient.init();
+  });
+
+  describe('eth_accounts', () => {
+    it('should return connected accounts', async () => {
+      const accounts = await MossWalletSdkClient.provider!.request({
+        method: 'eth_accounts',
+      });
+      expect(accounts).toEqual(['0xabc123']);
+    });
+  });
+
+  describe('eth_requestAccounts', () => {
+    it('should connect and return accounts', async () => {
+      (mega.connect as jest.Mock).mockResolvedValue(connectedStatus);
+
+      const accounts = await MossWalletSdkClient.provider!.request({
+        method: 'eth_requestAccounts',
+      });
+      expect(accounts).toEqual(['0xabc123']);
+    });
+
+    it('should throw when user rejects', async () => {
+      (mega.connect as jest.Mock).mockResolvedValue({
+        status: 'cancelled',
+        network: 'mainnet',
+      });
+
+      await expect(
+        MossWalletSdkClient.provider!.request({ method: 'eth_requestAccounts' }),
+      ).rejects.toThrow('User rejected the connection request.');
+    });
+  });
+
+  describe('eth_chainId', () => {
+    it('should return mainnet chain id as hex', async () => {
+      const chainId = await MossWalletSdkClient.provider!.request({
+        method: 'eth_chainId',
+      });
+      expect(chainId).toBe(`0x${(6342).toString(16)}`);
+    });
+  });
+
+  describe('personal_sign', () => {
+    it('should sign a message', async () => {
+      (mega.signMessage as jest.Mock).mockResolvedValue({
+        status: 'success',
+        signature: '0xsig',
+      });
+
+      const sig = await MossWalletSdkClient.provider!.request({
+        method: 'personal_sign',
+        params: ['0x48656c6c6f', '0xabc123'],
+      });
+      expect(sig).toBe('0xsig');
+    });
+
+    it('should throw when not connected', async () => {
+      (mega.initialise as jest.Mock).mockResolvedValue(disconnectedStatus);
+      MossWalletSdkClient.isInitialized = false;
+      MossWalletSdkClient.provider = undefined;
+      await MossWalletSdkClient.init();
+
+      await expect(
+        MossWalletSdkClient.provider!.request({
+          method: 'personal_sign',
+          params: ['0x48656c6c6f', '0xabc123'],
+        }),
+      ).rejects.toThrow('Not connected to MOSS Wallet.');
+    });
+
+    it('should throw when sign is cancelled', async () => {
+      (mega.signMessage as jest.Mock).mockResolvedValue({
+        status: 'cancelled',
+      });
+
+      await expect(
+        MossWalletSdkClient.provider!.request({
+          method: 'personal_sign',
+          params: ['0x48656c6c6f', '0xabc123'],
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('eth_signTypedData_v4', () => {
+    it('should sign typed data from JSON string', async () => {
+      (mega.signData as jest.Mock).mockResolvedValue({
+        status: 'success',
+        signature: '0xtyped',
+      });
+
+      const sig = await MossWalletSdkClient.provider!.request({
+        method: 'eth_signTypedData_v4',
+        params: ['0xabc123', JSON.stringify({ domain: {}, message: {} })],
+      });
+      expect(sig).toBe('0xtyped');
+    });
+
+    it('should sign typed data from object', async () => {
+      (mega.signData as jest.Mock).mockResolvedValue({
+        status: 'success',
+        signature: '0xtyped',
+      });
+
+      const sig = await MossWalletSdkClient.provider!.request({
+        method: 'eth_signTypedData_v4',
+        params: ['0xabc123', { domain: {}, message: {} }],
+      });
+      expect(sig).toBe('0xtyped');
+    });
+  });
+
+  describe('eth_sendTransaction', () => {
+    it('should send a transaction', async () => {
+      (mega.callContract as jest.Mock).mockResolvedValue({
+        status: 'approved',
+        receipt: { hash: '0xtxhash' },
+      });
+
+      const hash = await MossWalletSdkClient.provider!.request({
+        method: 'eth_sendTransaction',
+        params: [{ to: '0xdeadbeef' as `0x${string}`, value: '0x0' }],
+      });
+      expect(hash).toBe('0xtxhash');
+    });
+
+    it('should throw when transaction fails', async () => {
+      (mega.callContract as jest.Mock).mockResolvedValue({
+        status: 'error',
+        error: 'TX failed',
+      });
+
+      await expect(
+        MossWalletSdkClient.provider!.request({
+          method: 'eth_sendTransaction',
+          params: [{ to: '0xdeadbeef' as `0x${string}` }],
+        }),
+      ).rejects.toThrow('TX failed');
+    });
+  });
+
+  describe('unsupported method', () => {
+    it('should throw for unknown methods', async () => {
+      await expect(
+        MossWalletSdkClient.provider!.request({ method: 'eth_unknown' }),
+      ).rejects.toThrow('Method not supported: eth_unknown');
+    });
+  });
+
+  describe('event listeners', () => {
+    it('should add and remove listeners', () => {
+      const listener = jest.fn();
+      MossWalletSdkClient.provider!.on('accountsChanged', listener);
+      MossWalletSdkClient.provider!.removeListener('accountsChanged', listener);
+
+      // Trigger status change — listener should not be called
+      const onStatusChange = (mega.events.onStatusChange as jest.Mock).mock
+        .calls[0][0];
+      onStatusChange(connectedStatus);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/@dynamic-labs-connectors/moss-evm/src/MossWalletSdkClient.ts
+++ b/packages/@dynamic-labs-connectors/moss-evm/src/MossWalletSdkClient.ts
@@ -1,0 +1,195 @@
+import { mega } from '@megaeth-labs/wallet-sdk';
+import type { Config as MossConfig, ConnectionStatus } from '@megaeth-labs/wallet-sdk';
+import { logger } from '@dynamic-labs/wallet-connector-core';
+import type { IEthereum } from '@dynamic-labs/ethereum';
+import { hexToString, isAddress, isHex } from 'viem';
+import { megaeth, megaethTestnet } from 'viem/chains';
+
+const NETWORK_TO_CHAIN_ID = {
+  mainnet: megaeth.id,
+  testnet: megaethTestnet.id,
+} as const satisfies Record<string, number>;
+
+type Listener = (...args: unknown[]) => void;
+
+class MossEip1193Provider {
+  private readonly listeners = new Map<string, Set<Listener>>();
+  private account: `0x${string}` | undefined;
+  private chainIdHex: string;
+
+  constructor(chainId: number) {
+    this.chainIdHex = `0x${chainId.toString(16)}`;
+  }
+
+  applyStatus(status: ConnectionStatus | undefined) {
+    const next =
+      status?.status === 'connected' && status.address
+        ? (status.address as `0x${string}`)
+        : undefined;
+    const prev = this.account;
+    this.account = next;
+
+    if (prev !== next) {
+      this.emit('accountsChanged', next ? [next] : []);
+    }
+    if (!prev && next) {
+      this.emit('connect', { chainId: this.chainIdHex });
+    }
+    if (prev && !next) {
+      this.emit('disconnect', new Error('MOSS Wallet disconnected.'));
+    }
+  }
+
+  async request({
+    method,
+    params,
+  }: {
+    method: string;
+    params?: unknown[];
+  }): Promise<unknown> {
+    switch (method) {
+      case 'eth_accounts':
+        return this.account ? [this.account] : [];
+
+      case 'eth_chainId':
+        return this.chainIdHex;
+
+      case 'eth_requestAccounts': {
+        const status = await mega.connect();
+        this.applyStatus(status);
+        if (status.status !== 'connected' || !status.address) {
+          throw new Error('User rejected the connection request.');
+        }
+        return [status.address];
+      }
+
+      case 'personal_sign': {
+        if (!this.account) {
+          throw new Error('Not connected to MOSS Wallet.');
+        }
+        const args = params as [string, string];
+        const [first, second] = args;
+
+        // Handle legacy reversed order [address, message]
+        let message = first;
+        if (isAddress(first) && !isAddress(second)) {
+          message = second;
+        }
+
+        if (isHex(message)) {
+          message = hexToString(message);
+        }
+
+        const result = await mega.signMessage(message);
+        if (result.status !== 'success' || !result.signature) {
+          throw new Error(result.error ?? 'MOSS Wallet sign message failed.');
+        }
+        return result.signature;
+      }
+
+      case 'eth_signTypedData_v4': {
+        if (!this.account) {
+          throw new Error('Not connected to MOSS Wallet.');
+        }
+        const [, rawTypedData] = params as [string, string | object];
+        const data =
+          typeof rawTypedData === 'string'
+            ? JSON.parse(rawTypedData)
+            : rawTypedData;
+        const result = await mega.signData({ data });
+        if (result.status !== 'success' || !result.signature) {
+          throw new Error(result.error ?? 'MOSS Wallet sign typed data failed.');
+        }
+        return result.signature;
+      }
+
+      case 'eth_sendTransaction': {
+        if (!this.account) {
+          throw new Error('Not connected to MOSS Wallet.');
+        }
+        const [tx] = params as [
+          { to: `0x${string}`; value?: string; data?: `0x${string}` },
+        ];
+        const result = await mega.callContract({
+          address: tx.to,
+          value: tx.value !== undefined ? BigInt(tx.value) : 0n,
+          data: tx.data,
+        });
+        if (result.status !== 'approved' || !result.receipt?.hash) {
+          throw new Error(result.error ?? 'MOSS Wallet transaction failed.');
+        }
+        return result.receipt.hash;
+      }
+
+      default:
+        throw new Error(`Method not supported: ${method}`);
+    }
+  }
+
+  on(event: string, listener: Listener) {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event)!.add(listener);
+  }
+
+  removeListener(event: string, listener: Listener) {
+    this.listeners.get(event)?.delete(listener);
+  }
+
+  private emit(event: string, ...args: unknown[]) {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+}
+
+export class MossWalletSdkClient {
+  static isInitialized = false;
+  static provider: MossEip1193Provider | undefined;
+
+  private constructor() {
+    throw new Error('MossWalletSdkClient is not instantiable');
+  }
+
+  static init = async (config?: Partial<MossConfig>): Promise<void> => {
+    if (MossWalletSdkClient.isInitialized) {
+      return;
+    }
+
+    MossWalletSdkClient.isInitialized = true;
+
+    logger.debug('[MossWalletSdkClient] initializing');
+
+    const mergedConfig: MossConfig = { network: 'mainnet', ...config };
+    const initialStatus =
+      (await mega.initialise(mergedConfig)) ?? (await mega.status());
+
+    const network = initialStatus.network as keyof typeof NETWORK_TO_CHAIN_ID;
+    const chainId = NETWORK_TO_CHAIN_ID[network] ?? NETWORK_TO_CHAIN_ID.mainnet;
+    const provider = new MossEip1193Provider(chainId);
+    provider.applyStatus(initialStatus);
+
+    mega.events.onStatusChange((status) => {
+      provider.applyStatus(status);
+    });
+
+    MossWalletSdkClient.provider = provider;
+
+    logger.debug('[MossWalletSdkClient] initialized');
+  };
+
+  static getAddress = async (): Promise<string | undefined> => {
+    if (!MossWalletSdkClient.provider) {
+      return undefined;
+    }
+    const accounts = (await MossWalletSdkClient.provider.request({
+      method: 'eth_accounts',
+    })) as string[];
+    return accounts[0];
+  };
+
+  static getProvider = (): IEthereum | undefined => {
+    return MossWalletSdkClient.provider as unknown as IEthereum | undefined;
+  };
+}

--- a/packages/@dynamic-labs-connectors/moss-evm/src/index.spec.ts
+++ b/packages/@dynamic-labs-connectors/moss-evm/src/index.spec.ts
@@ -1,0 +1,7 @@
+import { MossEvmWalletConnectors, MossEvmWalletConnector } from './index.js';
+
+describe('MossEvmWalletConnectors', () => {
+  it('should always return the MossEvmWalletConnector', () => {
+    expect(MossEvmWalletConnectors({})).toEqual([MossEvmWalletConnector]);
+  });
+});

--- a/packages/@dynamic-labs-connectors/moss-evm/src/index.ts
+++ b/packages/@dynamic-labs-connectors/moss-evm/src/index.ts
@@ -1,0 +1,10 @@
+import { type WalletConnectorConstructor } from '@dynamic-labs/wallet-connector-core';
+
+import { MossEvmWalletConnector } from './MossEvmWalletConnector.js';
+
+export { MossEvmWalletConnector } from './MossEvmWalletConnector.js';
+
+export const MossEvmWalletConnectors = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars -- we don't care about the props
+  _props: any
+): WalletConnectorConstructor[] => [MossEvmWalletConnector];

--- a/packages/@dynamic-labs-connectors/moss-evm/tsconfig.json
+++ b/packages/@dynamic-labs-connectors/moss-evm/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {},
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/@dynamic-labs-connectors/moss-evm/tsconfig.lib.json
+++ b/packages/@dynamic-labs-connectors/moss-evm/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/@dynamic-labs-connectors/moss-evm/tsconfig.spec.json
+++ b/packages/@dynamic-labs-connectors/moss-evm/tsconfig.spec.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,7 +291,7 @@ importers:
     dependencies:
       '@dynamic-labs/ethereum':
         specifier: ^4.88.7
-        version: 4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(@types/react@19.2.2)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@9.0.21)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@5.5.4)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))(zod@4.0.5)
+        version: 4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(@types/react@19.2.2)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))(zod@4.0.5)
       '@dynamic-labs/ethereum-core':
         specifier: ^4.88.7
         version: 4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))
@@ -319,6 +319,24 @@ importers:
       bs58:
         specifier: ^6.0.0
         version: 6.0.0
+
+  packages/@dynamic-labs-connectors/moss-evm:
+    dependencies:
+      '@dynamic-labs/ethereum':
+        specifier: ^4.31.2
+        version: 4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(@types/react@19.2.2)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))(zod@4.0.5)
+      '@dynamic-labs/ethereum-core':
+        specifier: ^4.31.2
+        version: 4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))
+      '@dynamic-labs/wallet-connector-core':
+        specifier: ^4.31.2
+        version: 4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10)
+      '@megaeth-labs/wallet-sdk':
+        specifier: '>=0.1.19 <1.0.0'
+        version: 0.1.27
+      viem:
+        specifier: ^2.21.55
+        version: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5)
 
   packages/@dynamic-labs-connectors/safe-evm:
     dependencies:
@@ -2183,6 +2201,9 @@ packages:
 
   '@lit/reactive-element@2.1.1':
     resolution: {integrity: sha512-N+dm5PAYdQ8e6UlywyyrgI2t++wFGXfHx+dSJ1oBrg6FAxUj40jId++EaRm80MKX5JnlH1sBsyZ5h0bcZKemCg==}
+
+  '@megaeth-labs/wallet-sdk@0.1.27':
+    resolution: {integrity: sha512-wThWFa/JTFvcHkNQrrfDyeq3i01DxCBR7t8hQj9ILYxQsl6Q/VCHq0AicG8r4ukyHKw16qxMzsUdJskeRKGQrg==}
 
   '@metamask/analytics@0.4.0':
     resolution: {integrity: sha512-QKjVu8RsbjeSfXXhRLvOVdWJ0jUrVdXFwa4I1VyoI7LapWS6T0apTSjM8nLJKN1NADbpSYm7ctyuTyaHlG/0yA==}
@@ -7038,6 +7059,9 @@ packages:
     resolution: {integrity: sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==}
     engines: {node: '>=14.16'}
 
+  penpal@7.0.6:
+    resolution: {integrity: sha512-iZ70OhtiZ959V57j7vSKBuv1UEXwCEu7C+TK7YxAkrB1JahB4pElHs1S1ThzMuGYNQ+SbExOXmvqrEeGwX/A8g==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -9775,6 +9799,26 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@base-org/account@1.1.1(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5)':
+    dependencies:
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.5.4)(zod@4.0.5)
+      preact: 10.29.1
+      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5)
+      zustand: 5.0.3(@types/react@19.2.2)(immer@9.0.21)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@btckit/types@0.0.19': {}
@@ -9837,7 +9881,7 @@ snapshots:
       react-query: 3.39.3(react-dom@18.3.1(react@18.3.1))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@18.3.1)
       starknet: 6.24.1
       swr: 2.3.6(react@18.3.1)
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -9932,7 +9976,7 @@ snapshots:
       clsx: 1.2.1
       eventemitter3: 5.0.1
       preact: 10.29.1
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -9945,7 +9989,7 @@ snapshots:
       clsx: 1.2.1
       eventemitter3: 5.0.1
       preact: 10.29.1
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -10088,9 +10132,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@dynamic-labs-connectors/base-account-evm@4.6.8(@dynamic-labs/ethereum-core@4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5)))(@dynamic-labs/wallet-connector-core@4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10))(@types/react@19.2.2)(bufferutil@4.0.9)(immer@9.0.21)(react@19.2.3)(typescript@5.5.4)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))(zod@4.0.5)':
+  '@dynamic-labs-connectors/base-account-evm@4.6.8(@dynamic-labs/ethereum-core@4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5)))(@dynamic-labs/wallet-connector-core@4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))(zod@4.0.5)':
     dependencies:
-      '@base-org/account': 1.1.1(@types/react@19.2.2)(bufferutil@4.0.9)(immer@9.0.21)(react@19.2.3)(typescript@5.5.4)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@4.0.5)
+      '@base-org/account': 1.1.1(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5)
       '@dynamic-labs/ethereum-core': 4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))
       '@dynamic-labs/wallet-connector-core': 4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10)
       viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5)
@@ -10104,9 +10148,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@dynamic-labs-connectors/metamask-evm@4.6.8(af31833d6e67a3c7033347a62a14d919)':
+  '@dynamic-labs-connectors/metamask-evm@4.6.8(8e30df4c1affabf37613553dfdcac4aa)':
     dependencies:
-      '@dynamic-labs/ethereum': 4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(@types/react@19.2.2)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@9.0.21)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@5.5.4)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))(zod@4.0.5)
+      '@dynamic-labs/ethereum': 4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(@types/react@19.2.2)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))(zod@4.0.5)
       '@dynamic-labs/ethereum-core': 4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))
       '@dynamic-labs/wallet-connector-core': 4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10)
       '@metamask/connect-evm': 1.3.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -10351,6 +10395,21 @@ snapshots:
       - react
       - react-dom
 
+  '@dynamic-labs/ethereum-core@4.31.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.31.2
+      '@dynamic-labs/logger': 4.31.2
+      '@dynamic-labs/rpc-providers': 4.31.2
+      '@dynamic-labs/sdk-api-core': 0.0.762
+      '@dynamic-labs/types': 4.31.2
+      '@dynamic-labs/utils': 4.31.2
+      '@dynamic-labs/wallet-book': 4.31.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@dynamic-labs/wallet-connector-core': 4.31.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@dynamic-labs/ethereum-core@4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))':
     dependencies:
       '@dynamic-labs/assert-package-version': 4.89.0
@@ -10455,11 +10514,11 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@dynamic-labs/ethereum@4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(@types/react@19.2.2)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@9.0.21)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@5.5.4)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))(zod@4.0.5)':
+  '@dynamic-labs/ethereum@4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(@types/react@19.2.2)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))(zod@4.0.5)':
     dependencies:
       '@coinbase/wallet-sdk': 4.3.7(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5)
-      '@dynamic-labs-connectors/base-account-evm': 4.6.8(@dynamic-labs/ethereum-core@4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5)))(@dynamic-labs/wallet-connector-core@4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10))(@types/react@19.2.2)(bufferutil@4.0.9)(immer@9.0.21)(react@19.2.3)(typescript@5.5.4)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))(zod@4.0.5)
-      '@dynamic-labs-connectors/metamask-evm': 4.6.8(af31833d6e67a3c7033347a62a14d919)
+      '@dynamic-labs-connectors/base-account-evm': 4.6.8(@dynamic-labs/ethereum-core@4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5)))(@dynamic-labs/wallet-connector-core@4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))(zod@4.0.5)
+      '@dynamic-labs-connectors/metamask-evm': 4.6.8(8e30df4c1affabf37613553dfdcac4aa)
       '@dynamic-labs/assert-package-version': 4.89.0
       '@dynamic-labs/embedded-wallet-evm': 4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))(zod@4.0.5)
       '@dynamic-labs/ethereum-core': 4.89.0(@dynamic-labs-wallet/primitives@1.0.16)(bufferutil@4.0.9)(react-dom@19.2.3(react@19.2.3))(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5))
@@ -10796,14 +10855,14 @@ snapshots:
   '@dynamic-labs/waas-evm@4.31.2(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)':
     dependencies:
       '@dynamic-labs/assert-package-version': 4.31.2
-      '@dynamic-labs/ethereum-core': 4.31.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))
+      '@dynamic-labs/ethereum-core': 4.31.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))
       '@dynamic-labs/logger': 4.31.2
       '@dynamic-labs/sdk-api-core': 0.0.762
       '@dynamic-labs/types': 4.31.2
       '@dynamic-labs/utils': 4.31.2
-      '@dynamic-labs/waas': 4.31.2(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))
+      '@dynamic-labs/waas': 4.31.2(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))
       '@dynamic-labs/wallet-connector-core': 4.31.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
     transitivePeerDependencies:
       - '@gql.tada/svelte-support'
       - '@gql.tada/vue-support'
@@ -10849,11 +10908,11 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@dynamic-labs/waas@4.31.2(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))':
+  '@dynamic-labs/waas@4.31.2(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))':
     dependencies:
       '@dynamic-labs-wallet/browser-wallet-client': 0.0.144
       '@dynamic-labs/assert-package-version': 4.31.2
-      '@dynamic-labs/ethereum-core': 4.31.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))
+      '@dynamic-labs/ethereum-core': 4.31.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))
       '@dynamic-labs/sdk-api-core': 0.0.762
       '@dynamic-labs/solana-core': 4.31.2(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.5.4)(utf-8-validate@5.0.10)
       '@dynamic-labs/sui-core': 4.31.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.5.4)
@@ -11620,6 +11679,10 @@ snapshots:
   '@lit/reactive-element@2.1.1':
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.4.0
+
+  '@megaeth-labs/wallet-sdk@0.1.27':
+    dependencies:
+      penpal: 7.0.6
 
   '@metamask/analytics@0.4.0':
     dependencies:
@@ -12778,7 +12841,7 @@ snapshots:
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -12789,7 +12852,7 @@ snapshots:
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -12824,7 +12887,7 @@ snapshots:
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
       '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
       valtio: 1.13.2(@types/react@19.2.2)(react@18.3.1)
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -12859,7 +12922,7 @@ snapshots:
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
       '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.3)
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -13265,7 +13328,7 @@ snapshots:
       '@walletconnect/logger': 2.1.2
       '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
       valtio: 1.13.2(@types/react@19.2.2)(react@18.3.1)
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -13303,7 +13366,7 @@ snapshots:
       '@walletconnect/logger': 2.1.2
       '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.3)
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -13407,7 +13470,7 @@ snapshots:
       '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.2)(react@18.3.1)
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -13450,7 +13513,7 @@ snapshots:
       '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.3)
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -13539,7 +13602,7 @@ snapshots:
   '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -14165,7 +14228,7 @@ snapshots:
       '@turnkey/crypto': 2.3.1
       '@turnkey/encoding': 0.4.0
     optionalDependencies:
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -14177,7 +14240,7 @@ snapshots:
       '@turnkey/crypto': 2.5.0
       '@turnkey/encoding': 0.5.0
     optionalDependencies:
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -14189,7 +14252,7 @@ snapshots:
       '@turnkey/crypto': 2.5.0
       '@turnkey/encoding': 0.5.0
     optionalDependencies:
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5)
+      viem: 2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.0.5)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -19353,6 +19416,21 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  ox@0.14.29(typescript@5.5.4):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.0
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.5.4)(zod@4.0.5)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - zod
+
   ox@0.14.29(typescript@5.5.4)(zod@3.22.4):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
@@ -19390,7 +19468,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.5.4)(zod@4.0.5)
+      abitype: 1.2.3(typescript@5.5.4)(zod@4.0.5)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.5.4
@@ -19404,7 +19482,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.5.4)(zod@3.22.4)
+      abitype: 1.2.3(typescript@5.5.4)(zod@3.22.4)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.5.4
@@ -19418,7 +19496,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.5.4)(zod@3.22.4)
+      abitype: 1.2.3(typescript@5.5.4)(zod@3.22.4)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.5.4
@@ -19432,7 +19510,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.5.4)(zod@4.0.5)
+      abitype: 1.2.3(typescript@5.5.4)(zod@4.0.5)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.5.4
@@ -19447,7 +19525,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.5.4)(zod@4.0.5)
+      abitype: 1.2.3(typescript@5.5.4)(zod@4.0.5)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.5.4
@@ -19462,22 +19540,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.5.4)(zod@3.22.4)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.5.4
-    transitivePeerDependencies:
-      - zod
-
-  ox@0.9.3(typescript@5.5.4):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.0
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.5.4)(zod@4.0.5)
+      abitype: 1.2.3(typescript@5.5.4)(zod@3.22.4)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.5.4
@@ -19492,7 +19555,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.5.4)(zod@3.22.4)
+      abitype: 1.2.3(typescript@5.5.4)(zod@3.22.4)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.5.4
@@ -19507,7 +19570,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.5.4)(zod@4.0.5)
+      abitype: 1.2.3(typescript@5.5.4)(zod@4.0.5)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.5.4
@@ -19578,6 +19641,8 @@ snapshots:
   path-type@4.0.0: {}
 
   peek-readable@5.4.2: {}
+
+  penpal@7.0.6: {}
 
   picocolors@1.1.1: {}
 
@@ -21382,23 +21447,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.5.4)(zod@4.0.5)
-      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      ox: 0.9.3(typescript@5.5.4)
-      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 5.5.4
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
   viem@2.37.5(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4):
     dependencies:
       '@noble/curves': 1.9.1
@@ -21426,6 +21474,23 @@ snapshots:
       isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.9.3(typescript@5.5.4)(zod@4.0.5)
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.52.2(bufferutil@4.0.9)(typescript@5.5.4)(utf-8-validate@5.0.10):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.5.4)(zod@4.0.5)
+      isows: 1.0.7(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      ox: 0.14.29(typescript@5.5.4)
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -32,6 +32,9 @@
       "@dynamic-labs-connectors/intersend-evm": [
         "packages/@dynamic-labs-connectors/intersend-evm/src/index.ts"
       ],
+      "@dynamic-labs-connectors/moss-evm": [
+        "packages/@dynamic-labs-connectors/moss-evm/src/index.ts"
+      ],
       "@dynamic-labs-connectors/safe-evm": [
         "packages/@dynamic-labs-connectors/safe-evm/src/index.ts"
       ],


### PR DESCRIPTION
Adds @dynamic-labs-connectors/moss-evm — a Dynamic Labs connector for MOSS Wallet (MegaETH). Follows the safe-evm pattern:

- MossWalletSdkClient: singleton wrapping @megaeth-labs/wallet-sdk with a minimal EIP-1193 provider (eth_accounts, eth_chainId, eth_requestAccounts, personal_sign, eth_signTypedData_v4, eth_sendTransaction, status-change events)
- MossEvmWalletConnector: extends EthereumInjectedConnector, sets canConnectViaCustodialService=true, disables network switching
- MossEvmWalletConnectors factory always returns the connector (no isInIframe() guard unlike Safe)
- 40 unit tests, build passing
- jest-config/mocks/metamask-evm.js added to unblock ESM issue in tests (same problem already present in safe-evm and intersend-evm)