### PR TITLE
fix: delegate to injected provider when MetaMask extension is installed

### DIFF
--- a/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.spec.ts
+++ b/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.spec.ts
@@ -14,6 +14,7 @@ jest.mock('@dynamic-labs/ethereum', () => {
     public evmNetworks: any[] = [];
     public ethProviderHelper: any;
     public constructorProps: any;
+    public teardownEventListeners: (() => void) | undefined;
     constructor(props: any) {
       this.constructorProps = props;
       this._metadata = props?.metadata;
@@ -23,13 +24,27 @@ jest.mock('@dynamic-labs/ethereum', () => {
       return this._metadata;
     }
     findProvider() {
-      return undefined;
+      return this.ethProviderHelper?.getInstalledProvider();
     }
     isInstalledOnBrowser() {
       return false;
     }
-    endSession() {
-      return Promise.resolve();
+    async getAddress() {
+      return this.ethProviderHelper?.getAddress();
+    }
+    async setupEventListeners() {
+      if (!this.ethProviderHelper) return;
+      const { tearDownEventListeners } = this.ethProviderHelper._setupEventListeners(this);
+      this.teardownEventListeners = tearDownEventListeners;
+    }
+    async endSession() {
+      const provider = this.ethProviderHelper?.findProvider();
+      if (!provider) return;
+      await provider.request({
+        method: 'wallet_revokePermissions',
+        params: [{ eth_accounts: {} }],
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      }).catch(() => {});
     }
   }
   return { EthereumInjectedConnector };
@@ -146,6 +161,24 @@ describe('MetaMaskEvmWalletConnector', () => {
       });
       Object.defineProperty(connector, '_metadata', {
         value: { rdns: 'io.metamask' },
+        writable: true,
+      });
+
+      expect(connector.isInstalledOnBrowser()).toBe(false);
+    });
+
+    it('should return false when metadata is undefined', () => {
+      Object.defineProperty(connector, '_metadata', {
+        value: undefined,
+        writable: true,
+      });
+
+      expect(connector.isInstalledOnBrowser()).toBe(false);
+    });
+
+    it('should return false when metadata.rdns is undefined', () => {
+      Object.defineProperty(connector, '_metadata', {
+        value: { rdns: undefined },
         writable: true,
       });
 
@@ -275,7 +308,7 @@ describe('MetaMaskEvmWalletConnector', () => {
       connector.findProvider();
 
       expect(logger.logVerboseTroubleshootingMessage).toHaveBeenCalledWith(
-        '[MetaMaskEvmWalletConnector] findProvider',
+        '[MetaMaskEvmWalletConnector] findProvider (SDK)',
         { provider: mockProvider },
       );
     });
@@ -697,6 +730,115 @@ describe('MetaMaskEvmWalletConnector', () => {
 
       const networks = await connector.getSupportedNetworks();
       expect(networks).toEqual(['1', '137', '137']);
+    });
+  });
+
+  describe('extension-installed delegation', () => {
+    let extensionConnector: MetaMaskEvmWalletConnector;
+    let mockInjectedProvider: any;
+
+    beforeEach(() => {
+      extensionConnector = new MetaMaskEvmWalletConnector(walletConnectorProps);
+      mockInjectedProvider = {
+        request: jest.fn().mockResolvedValue(['0xExtensionAccount']),
+        on: jest.fn(),
+        removeListener: jest.fn(),
+      };
+
+      // Set up metadata and ethProviderHelper so isInstalledOnBrowser() returns true
+      Object.defineProperty(extensionConnector, '_metadata', {
+        value: { rdns: 'io.metamask' },
+        writable: true,
+      });
+      Object.defineProperty(extensionConnector, 'ethProviderHelper', {
+        value: {
+          eip6963ProviderLookup: jest.fn().mockReturnValue({ provider: mockInjectedProvider }),
+          getInstalledProvider: jest.fn().mockReturnValue(mockInjectedProvider),
+          getAddress: jest.fn().mockResolvedValue('0xExtensionAccount'),
+          findProvider: jest.fn().mockReturnValue(mockInjectedProvider),
+          _setupEventListeners: jest.fn().mockReturnValue({ tearDownEventListeners: jest.fn() }),
+        },
+        writable: true,
+      });
+    });
+
+    it('should delegate findProvider to parent when extension is installed', () => {
+      const result = extensionConnector.findProvider();
+      expect(result).toBe(mockInjectedProvider);
+      expect(MetaMaskSdkClient.getProvider).not.toHaveBeenCalled();
+    });
+
+    it('should delegate getAddress to parent when extension is installed', async () => {
+      const address = await extensionConnector.getAddress();
+      expect(address).toBe('0xExtensionAccount');
+      expect(MetaMaskSdkClient.connect).not.toHaveBeenCalled();
+    });
+
+    it('should delegate setupEventListeners to parent when extension is installed', async () => {
+      await extensionConnector.setupEventListeners();
+      expect(extensionConnector.ethProviderHelper._setupEventListeners).toHaveBeenCalled();
+      expect(MetaMaskSdkClient.getProvider).not.toHaveBeenCalled();
+    });
+
+    it('should delegate getConnectedAccounts to extension provider when installed', async () => {
+      const accounts = await extensionConnector.getConnectedAccounts();
+      expect(mockInjectedProvider.request).toHaveBeenCalledWith({
+        method: 'eth_accounts',
+      });
+      expect(accounts).toEqual(['0xExtensionAccount']);
+    });
+
+    it('should delegate endSession to parent when extension is installed', async () => {
+      // Parent's endSession calls wallet_revokePermissions via findProvider
+      mockInjectedProvider.request.mockResolvedValue(undefined);
+      Object.defineProperty(extensionConnector, 'ethProviderHelper', {
+        value: {
+          eip6963ProviderLookup: jest.fn().mockReturnValue({ provider: mockInjectedProvider }),
+          getInstalledProvider: jest.fn().mockReturnValue(mockInjectedProvider),
+          findProvider: jest.fn().mockReturnValue(mockInjectedProvider),
+        },
+        writable: true,
+      });
+
+      await extensionConnector.endSession();
+      expect(MetaMaskSdkClient.disconnect).not.toHaveBeenCalled();
+    });
+
+    it('should use SDK path for findProvider when extension is NOT installed', () => {
+      // Remove the EIP-6963 provider to simulate no extension
+      Object.defineProperty(extensionConnector, 'ethProviderHelper', {
+        value: {
+          eip6963ProviderLookup: jest.fn().mockReturnValue(undefined),
+          getInstalledProvider: jest.fn().mockReturnValue(undefined),
+        },
+        writable: true,
+      });
+
+      const mockSdkProvider = { selectedAccount: '0xSdk' };
+      (MetaMaskSdkClient.getProvider as jest.Mock).mockReturnValue(mockSdkProvider);
+
+      const result = extensionConnector.findProvider();
+      expect(result).toBeDefined();
+      expect(MetaMaskSdkClient.getProvider).toHaveBeenCalled();
+    });
+
+    it('should use SDK path for getAddress when extension is NOT installed', async () => {
+      Object.defineProperty(extensionConnector, 'ethProviderHelper', {
+        value: {
+          eip6963ProviderLookup: jest.fn().mockReturnValue(undefined),
+          getInstalledProvider: jest.fn().mockReturnValue(undefined),
+        },
+        writable: true,
+      });
+      Object.defineProperty(extensionConnector, 'evmNetworks', {
+        value: mockEvmNetworks,
+        writable: true,
+      });
+      (MetaMaskSdkClient.isInitialized as any) = true;
+
+      const address = await extensionConnector.getAddress();
+      expect(address).toBe('0x1234567890abcdef1234567890abcdef12345678');
+      expect(MetaMaskSdkClient.connect).toHaveBeenCalled();
     });
   });
 });

--- a/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.ts
+++ b/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.ts
@@ -15,6 +15,9 @@ import { toNumericChainId } from './utils.js';
 /**
  * MetaMask wallet connector for Dynamic.
  * Uses @metamask/connect-evm SDK with headless QR code support.
+ * When the MetaMask extension is installed on the browser, delegates
+ * to the parent injected-provider flow for native popup behavior.
+ * Falls back to the SDK protocol for QR code / mobile flows.
  */
 export class MetaMaskEvmWalletConnector extends EthereumInjectedConnector {
   override name = 'MetaMask';
@@ -27,8 +30,10 @@ export class MetaMaskEvmWalletConnector extends EthereumInjectedConnector {
    * Dynamic uses this to decide between "install extension" and QR code views.
    */
   override isInstalledOnBrowser() {
+    if (!this.metadata?.rdns) return false;
+
     const metaMaskEip6963Provider =
-      this.ethProviderHelper?.eip6963ProviderLookup(this.metadata.rdns!);
+      this.ethProviderHelper?.eip6963ProviderLookup(this.metadata.rdns);
 
     logger.logVerboseTroubleshootingMessage('[MetaMaskEvmWalletConnector] isInstalledOnBrowser', {
       metaMaskEip6963Provider,
@@ -62,20 +67,21 @@ export class MetaMaskEvmWalletConnector extends EthereumInjectedConnector {
   }
 
   /**
-   * Returns the SDK's EIP-1193 provider with minimal normalization.
-   * Only intercepts eth_requestAccounts to fix the SDK's non-standard
-   * response format ({accounts, chainId} -> accounts[]).
+   * When the extension is installed, returns its injected provider directly
+   * so all RPC calls (eth_requestAccounts, etc.) go through the extension
+   * and trigger native popups. Falls back to the SDK provider for QR/mobile.
    */
   override findProvider(): IEthereum | undefined {
+    if (this.isInstalledOnBrowser()) {
+      return super.findProvider();
+    }
+
     const provider = MetaMaskSdkClient.getProvider();
 
-    logger.logVerboseTroubleshootingMessage('[MetaMaskEvmWalletConnector] findProvider', {
+    logger.logVerboseTroubleshootingMessage('[MetaMaskEvmWalletConnector] findProvider (SDK)', {
       provider,
     });
 
-    // The new SDK always has a EIP-1193 provider available even if there is no established connection.
-    // If Dynamic assumes that a provider can only be available if there is an established connection,
-    // then this check is needed. If wrong, then this check can be removed.
     if (!provider?.selectedAccount) return undefined;
 
     return {
@@ -98,6 +104,10 @@ export class MetaMaskEvmWalletConnector extends EthereumInjectedConnector {
   }
 
   override async setupEventListeners(): Promise<void> {
+    if (this.isInstalledOnBrowser()) {
+      return super.setupEventListeners();
+    }
+
     const provider = MetaMaskSdkClient.getProvider();
 
     if (!provider) {
@@ -121,16 +131,17 @@ export class MetaMaskEvmWalletConnector extends EthereumInjectedConnector {
   override async getAddress(
     opts?: GetAddressOpts,
   ): Promise<string | undefined> {
+    // When extension is installed, use the standard injected flow
+    // (eth_requestAccounts → extension popup for account selection)
+    if (this.isInstalledOnBrowser()) {
+      return super.getAddress();
+    }
+
+    // SDK flow for QR code / mobile connections
     if (!MetaMaskSdkClient.isInitialized) {
       await this.init();
     }
 
-    // Not sure if this is needed. Was added in an attempt to fix the personal sign / linking account issues.
-    // I believe if getAddress() is called without onDisplayUri, the intention is that want to return the existing selected account if
-    // there is one. If onDisplayUri is provided, we don't want to return the existing selected account if there is one, instead we want to
-    // cause a connection prompt to be shown to the user so that they can establish a new connection.
-    // Delete this block if this assumption is incorrect. I don't have a strong thoughts on this, simply leaving it here since it was here while,
-    // we were debugging with Carla.
     if (!opts?.onDisplayUri) {
       try {
         const sdk = MetaMaskSdkClient.getInstance();
@@ -145,10 +156,6 @@ export class MetaMaskEvmWalletConnector extends EthereumInjectedConnector {
       : undefined;
 
     try {
-      // Not sure if this is needed. Was added in an attempt to fix the personal sign / linking account issues.
-      // If onDisplayUri is provided, then I assume we want to cause a connection prompt to be shown to the user. Explicitly disconnecting would guarantee
-      // that a new connection prompt is shown to the user, but that isn't strictly required.
-      // Delete this block if the above block that returns the selectedAccount early is not needed.
       if (opts?.onDisplayUri) {
         await MetaMaskSdkClient.disconnect();
       }
@@ -166,9 +173,25 @@ export class MetaMaskEvmWalletConnector extends EthereumInjectedConnector {
   }
 
   override async getConnectedAccounts(): Promise<string[]> {
-    // After a page reload, the SDK singleton is cleared but the MetaMask
-    // extension still holds the session. Re-initialize the SDK so it can
-    // restore accounts from the extension's persisted state.
+    // When extension is installed, query it directly via eth_accounts
+    if (this.isInstalledOnBrowser()) {
+      const provider = this.ethProviderHelper?.getInstalledProvider();
+      if (provider) {
+        try {
+          const accounts = (await provider.request({
+            method: 'eth_accounts',
+          })) as string[];
+          if (Array.isArray(accounts) && accounts.length) {
+            return accounts;
+          }
+        } catch {
+          // provider not available or errored
+        }
+      }
+      return [];
+    }
+
+    // SDK flow for QR/mobile
     if (!MetaMaskSdkClient.isInitialized) {
       try {
         await this.init();
@@ -187,8 +210,8 @@ export class MetaMaskEvmWalletConnector extends EthereumInjectedConnector {
     }
 
     // Fall back to checking the injected provider directly via eth_accounts.
-    // This handles the case where the extension has the session but the SDK
-    // hasn't restored it into its in-memory state yet.
+    // Covers edge cases where EIP-6963 announcement hasn't fired yet but
+    // the extension is present and holds an active session.
     const provider = this.ethProviderHelper?.getInstalledProvider();
     if (provider) {
       try {
@@ -207,10 +230,13 @@ export class MetaMaskEvmWalletConnector extends EthereumInjectedConnector {
   }
 
   override async endSession(): Promise<void> {
-    // Tear down event listeners BEFORE disconnecting to prevent the SDK's
-    // 'disconnect' event from propagating back to the Dynamic multi-wallet
-    // manager as an unexpected external disconnect (which would log out all
-    // wallets in connect-only mode).
+    if (this.isInstalledOnBrowser()) {
+      return super.endSession();
+    }
+
+    // SDK flow: tear down event listeners BEFORE disconnecting to prevent
+    // the SDK's 'disconnect' event from propagating back to Dynamic's
+    // multi-wallet manager as an unexpected external disconnect.
     this.teardownEventListeners?.();
     await MetaMaskSdkClient.disconnect();
   }


### PR DESCRIPTION
## Summary

With `useMetamaskSdk: true` (now the default), `MetaMaskEvmWalletConnector` was routing all RPC calls through the SDK's protocol channel — even when the MetaMask extension is installed. This prevented the extension's native notification popup from appearing for connections and transaction confirmations, breaking flows that rely on it (E2E tests, external wallet funding with multiple MetaMask accounts).

**Fix:** When the extension is detected via EIP-6963, delegate `findProvider()`, `getAddress()`, `setupEventListeners()`, `getConnectedAccounts()`, and `endSession()` to the parent `EthereumInjectedConnector` — standard `eth_requestAccounts` flow with popup. The SDK overrides only activate when the extension is NOT installed (QR code / mobile deep-link flows).

```typescript
override findProvider() {
  if (this.isInstalledOnBrowser()) return super.findProvider(); // extension popup
  // ... SDK provider for QR/mobile
}
```

Also adds a guard for undefined `metadata.rdns` in `isInstalledOnBrowser()`.

Link to Devin session: https://dynamicxyz.devinenterprise.com/sessions/40652b49f4a747f1b1f0b13449b64955
Requested by: @carlascarvalho