### PR TITLE
fix(metamask-solana): forward decoded public key on accountChanged

### DIFF
--- a/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.spec.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.spec.ts
@@ -353,8 +353,40 @@ describe('createWalletStandardAdapter', () => {
 
       const unsubscribe = adapter.on('accountChanged', listener);
 
-      expect(on).toHaveBeenCalledWith('change', listener);
+      expect(on).toHaveBeenCalledWith('change', expect.any(Function));
       expect(unsubscribe).toBe(off);
+    });
+
+    it('decodes the new public key and forwards it to the listener', () => {
+      const on = jest.fn();
+      const adapter = createWalletStandardAdapter(
+        buildWallet({ 'standard:events': { on } }),
+        getSelectedNetwork,
+      );
+      const listener = jest.fn();
+      adapter.on('accountChanged', listener);
+
+      const wrapped = on.mock.calls[0][1];
+      const publicKey = new TextEncoder().encode('SoLaNaNewKey');
+      wrapped({ accounts: [{ ...account, publicKey }] });
+
+      expect(listener).toHaveBeenCalledWith('SoLaNaNewKey');
+    });
+
+    it('ignores change events without an account public key', () => {
+      const on = jest.fn();
+      const adapter = createWalletStandardAdapter(
+        buildWallet({ 'standard:events': { on } }),
+        getSelectedNetwork,
+      );
+      const listener = jest.fn();
+      adapter.on('accountChanged', listener);
+
+      const wrapped = on.mock.calls[0][1];
+      wrapped({ accounts: [] });
+      wrapped({});
+
+      expect(listener).not.toHaveBeenCalled();
     });
 
     it('does not subscribe for unsupported events', () => {
@@ -367,6 +399,15 @@ describe('createWalletStandardAdapter', () => {
       adapter.on('disconnect', jest.fn());
 
       expect(on).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined when standard:events is unavailable', () => {
+      const adapter = createWalletStandardAdapter(
+        buildWallet({}),
+        getSelectedNetwork,
+      );
+
+      expect(adapter.on('accountChanged', jest.fn())).toBeUndefined();
     });
   });
 

--- a/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.ts
@@ -203,12 +203,28 @@ export function createWalletStandardAdapter(
     const onFn = features['standard:events']?.['on'] as
       | ((
           event: string,
-          listener: (...args: unknown[]) => void,
+          wrapped: (properties: {
+            accounts?: readonly WalletAccount[];
+          }) => void,
         ) => () => void)
       | undefined;
 
     if (!onFn || event !== 'accountChanged') return;
-    return onFn('change', listener);
+
+    // The wallet-standard 'change' event delivers a change-properties object,
+    // but ISolana 'accountChanged' subscribers expect the new account's
+    // public key string. Adapt the payload so consumers receive the same
+    // shape as Dynamic's generic wallet-standard signer.
+    const wrapped = (properties: {
+      accounts?: readonly WalletAccount[];
+    }): void => {
+      const publicKey = properties.accounts?.[0]?.publicKey;
+      if (publicKey) {
+        listener(new TextDecoder().decode(publicKey));
+      }
+    };
+
+    return onFn('change', wrapped);
   };
 
   const noop = () => {


### PR DESCRIPTION
## Summary

The adapter's `on('accountChanged', listener)` handed the raw wallet-standard `change` event straight to the ISolana subscriber, so the listener received a `{ accounts }` change-properties object instead of the public-key string the ISolana contract implies:

```ts
if (!onFn || event !== 'accountChanged') return;
return onFn('change', listener); // listener gets { accounts }, not a pubkey string
```

Dynamic's generic wallet-standard signer (`dynamic-auth` `createSolanaSignerFromWalletStandard`) wraps the change event and forwards the decoded public key. This PR does the same:

```ts
const wrapped = ({ accounts }) => {
  const publicKey = accounts?.[0]?.publicKey;
  if (publicKey) listener(new TextDecoder().decode(publicKey));
};
return onFn('change', wrapped);
```

Now subscribers of the signer's `accountChanged` receive the same payload shape as the generic signer.

## Tests
Extends `WalletStandardAdapter.spec.ts`: asserts the change event is wrapped, the decoded public key is forwarded, empty/absent accounts are ignored, and the missing-`standard:events` path returns undefined. Adapter coverage stays at 100%.

Note: PR 2 of 3. **Stacked on #172** (batch signing) — base is that branch; merge #172 first. Rebases onto `main` after #172 merges.

Link to Devin session: https://dynamicxyz.devinenterprise.com/sessions/5eed2ffd38f74488b9a426aca80d2769
Requested by: @carlascarvalho