### PR TITLE
fix(metamask-solana): sign with the active account, not always accounts[0]

### DIFF
--- a/packages/@dynamic-labs-connectors/metamask-solana/src/MetaMaskSolanaWalletConnector.spec.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/MetaMaskSolanaWalletConnector.spec.ts
@@ -334,6 +334,26 @@ describe('MetaMaskSolanaWalletConnector', () => {
       const clusterResolver = createWalletStandardAdapter.mock.calls.at(-1)[1];
       expect(clusterResolver()).toBe('mainnet');
     });
+
+    it('should pass a selected-address resolver to the wallet standard adapter', async () => {
+      const { createWalletStandardAdapter } = jest.requireMock(
+        './WalletStandardAdapter.js',
+      );
+      const mockWallet = { accounts: [{ address: 'SoLaNa1234' }] };
+      (MetaMaskSolanaSdkClient.getWallet as jest.Mock).mockReturnValue(
+        mockWallet,
+      );
+      (
+        MetaMaskSolanaSdkClient.getSelectedAccount as jest.Mock
+      ).mockReturnValue('SoLaNaActive');
+      (MetaMaskSolanaSdkClient.isInitialized as any) = true;
+
+      await connector.connect();
+
+      const selectedAddressResolver =
+        createWalletStandardAdapter.mock.calls.at(-1)[2];
+      expect(selectedAddressResolver()).toBe('SoLaNaActive');
+    });
   });
 
   describe('signMessage', () => {

--- a/packages/@dynamic-labs-connectors/metamask-solana/src/MetaMaskSolanaWalletConnector.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/MetaMaskSolanaWalletConnector.ts
@@ -235,9 +235,13 @@ export class MetaMaskSolanaWalletConnector extends SolanaWalletConnector {
       return undefined;
     }
 
-    return createWalletStandardAdapter(wallet, () => {
-      const network = this.getSelectedNetwork();
-      return network?.cluster ?? 'mainnet';
-    });
+    return createWalletStandardAdapter(
+      wallet,
+      () => {
+        const network = this.getSelectedNetwork();
+        return network?.cluster ?? 'mainnet';
+      },
+      () => MetaMaskSolanaSdkClient.getSelectedAccount(),
+    );
   }
 }

--- a/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.spec.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.spec.ts
@@ -151,6 +151,76 @@ describe('createWalletStandardAdapter', () => {
     });
   });
 
+  describe('account resolution', () => {
+    const secondAccount: WalletAccount = {
+      address: 'SoLaNaSecond',
+      publicKey: new Uint8Array([4, 5, 6]),
+      chains: ['solana:mainnet'],
+      features: [],
+    };
+
+    it('signs with the account matching the selected address', async () => {
+      const signTransaction = jest
+        .fn()
+        .mockResolvedValue([{ signedTransaction: new Uint8Array([10]) }]);
+      const wallet = buildWallet(
+        { 'solana:signTransaction': { signTransaction } },
+        [account, secondAccount],
+      );
+
+      const adapter = createWalletStandardAdapter(
+        wallet,
+        getSelectedNetwork,
+        () => secondAccount.address,
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await adapter.signTransaction(buildLegacyTransaction('a') as any);
+
+      expect(signTransaction.mock.calls[0][0]).toMatchObject({
+        account: secondAccount,
+      });
+    });
+
+    it('falls back to the first account when the selected address is not found', async () => {
+      const signTransaction = jest
+        .fn()
+        .mockResolvedValue([{ signedTransaction: new Uint8Array([10]) }]);
+      const wallet = buildWallet(
+        { 'solana:signTransaction': { signTransaction } },
+        [account, secondAccount],
+      );
+
+      const adapter = createWalletStandardAdapter(
+        wallet,
+        getSelectedNetwork,
+        () => 'SoLaNaUnknown',
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await adapter.signTransaction(buildLegacyTransaction('a') as any);
+
+      expect(signTransaction.mock.calls[0][0]).toMatchObject({ account });
+    });
+
+    it('falls back to the first account when no resolver is provided', async () => {
+      const signTransaction = jest
+        .fn()
+        .mockResolvedValue([{ signedTransaction: new Uint8Array([10]) }]);
+      const wallet = buildWallet(
+        { 'solana:signTransaction': { signTransaction } },
+        [account, secondAccount],
+      );
+
+      const adapter = createWalletStandardAdapter(wallet, getSelectedNetwork);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await adapter.signTransaction(buildLegacyTransaction('a') as any);
+
+      expect(signTransaction.mock.calls[0][0]).toMatchObject({ account });
+    });
+  });
+
   describe('signTransaction', () => {
     it('delegates to a single batched call', async () => {
       const signTransaction = jest

--- a/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.ts
@@ -15,11 +15,19 @@ import type { StandardWallet, WalletAccount } from './types.js';
 export function createWalletStandardAdapter(
   wallet: StandardWallet,
   getSelectedNetwork: () => string,
+  getSelectedAddress?: () => string | undefined,
 ): ISolana {
   const features = wallet.features;
 
   const getCurrentAccount = (): WalletAccount => {
-    const account = wallet.accounts[0];
+    const selectedAddress = getSelectedAddress?.();
+    const selectedAccount = selectedAddress
+      ? wallet.accounts.find((a) => a.address === selectedAddress)
+      : undefined;
+
+    // Prefer the account Dynamic considers active; fall back to the first
+    // connected account so we never sign with an unexpected account.
+    const account = selectedAccount ?? wallet.accounts[0];
     if (!account) {
       throw new Error('[WalletStandardAdapter] No connected account');
     }


### PR DESCRIPTION
## Summary

`WalletStandardAdapter.getCurrentAccount` always returned `wallet.accounts[0]`, so signing/sending could use the wrong account if the account Dynamic considers active isn't first:

```ts
const getCurrentAccount = () => wallet.accounts[0]; // ignores which account is active
```

Dynamic's generic wallet-standard signer resolves the account matching the connector's tracked address (`walletConnector.getAddress()`). This PR mirrors that: the adapter takes an optional `getSelectedAddress` resolver and picks the matching account, falling back to `accounts[0]`:

```ts
createWalletStandardAdapter(wallet, getSelectedNetwork, getSelectedAddress?)

const getCurrentAccount = () => {
  const selected = getSelectedAddress?.();
  const match = selected ? wallet.accounts.find(a => a.address === selected) : undefined;
  const account = match ?? wallet.accounts[0];
  if (!account) throw new Error('No connected account');
  return account;
};
```

The connector wires it to the SDK's selected account:

```ts
createWalletStandardAdapter(wallet, clusterResolver, () =>
  MetaMaskSolanaSdkClient.getSelectedAccount());
```

For the MetaMask Connect SDK today the selected account is effectively `accounts[0]`, so this is behavior-preserving in practice — but it removes the hard-coded assumption and keeps the adapter consistent with the generic signer for any future multi-account behavior.

## Tests
Adds account-resolution cases to `WalletStandardAdapter.spec.ts` (matches selected account, falls back when the selected address is missing or no resolver is provided) and a connector-spec assertion that the selected-address resolver is passed and resolves to `getSelectedAccount()`. Both changed files stay at 100% coverage.

Note: final PR of 3 addressing MetaMask-Solana-connector vs. generic-signer discrepancies. The first two (#172 batch signing, #173 accountChanged) have merged; this is now rebased standalone onto `main`.

Link to Devin session: https://dynamicxyz.devinenterprise.com/sessions/5eed2ffd38f74488b9a426aca80d2769
Requested by: @carlascarvalho