### PR TITLE
ci(release): pin npm to 11.x so publish keeps working on node 20

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -106,10 +106,13 @@ runs:
     - name: Upgrade npm for OIDC Trusted Publishing
       # npm's Trusted Publishing (OIDC) support was stabilized in npm 11.5.1.
       # Node 20 ships with npm ~10.8, so we upgrade before calling `npm publish`.
+      # Pin to the 11.x line: npm@latest now points at 12.x, which drops Node 20
+      # (engines: node ^22.22.2 || ...), whereas all of 11.x still supports it
+      # (engines: node ^20.17.0 || >=22.9.0).
       if: "${{ inputs.type == 'publish' }}"
       shell: bash
       run: |-
-        npm install -g npm@latest
+        npm install -g npm@11
         echo "npm: $(npm --version)"
     - name: Publish Packages to npm
       if: "${{ inputs.type == 'publish' }}"


### PR DESCRIPTION
## Summary

The Publish Packages workflow fails at the `Upgrade npm for OIDC Trusted Publishing` step in `.github/actions/release/action.yml`:

```
npm error notsup Not compatible with your version of node/npm: npm@12.0.0
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

Root cause: the step ran `npm install -g npm@latest`, and the `latest` dist-tag now points at **npm 12.x**, which dropped Node 20 support. The runner uses Node 20 (release action `version` default `20`, `.nvmrc` = `v20`), so the global install aborts with `EBADENGINE`.

This is *not* a project-`engines` problem, and the fix isn't in `publish-packages.yml` — that workflow just calls the composite `release` action, where the failing step lives.

Fix: pin the upgrade to the 11.x line, which still supports Node 20 and still has OIDC Trusted Publishing (stabilized in 11.5.1):

```diff
- npm install -g npm@latest
+ npm install -g npm@11   # latest 11.x, engines: node ^20.17.0 || >=22.9.0
```

`npm@11` currently resolves to 11.17.0 (`^20.17.0` satisfies the runner's 20.20.2) while never grabbing 12.x. Bumping the runner to Node 22 would also work but is a larger, riskier change; pinning npm is the minimal fix that keeps the existing Node 20 baseline.

No unit tests apply (CI-config-only change); verified by inspecting the published `engines` of the `npm@11` and `npm@latest`/`npm@12` dist-tags.

Link to Devin session: https://dynamicxyz.devinenterprise.com/sessions/5eed2ffd38f74488b9a426aca80d2769
Requested by: @carlascarvalho