### PR TITLE
fix(release): make GitHub release creation idempotent on re-publish

### DIFF
--- a/.github/actions/release/src/commands/publish-packages.ts
+++ b/.github/actions/release/src/commands/publish-packages.ts
@@ -50,19 +50,41 @@ const createRelease = async (
 
   if (!dryRun) {
     const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-    await oktokit.rest.repos.createRelease({
-      owner,
-      repo,
-      tag_name: gitTag,
-      target_commitish,
-      name: gitTag,
-      prerelease: isPrerelease,
-      body: changelogBody,
-      make_latest: isLatest ? 'true' : 'false',
-    })
+    try {
+      await oktokit.rest.repos.createRelease({
+        owner,
+        repo,
+        tag_name: gitTag,
+        target_commitish,
+        name: gitTag,
+        prerelease: isPrerelease,
+        body: changelogBody,
+        make_latest: isLatest ? 'true' : 'false',
+      })
+    } catch (error) {
+      // A release for this tag may already exist from a previous (failed)
+      // publish run. Treat that as non-fatal so re-running publish is
+      // idempotent and can still proceed to (re)publish any packages that are
+      // not yet on npm.
+      if (!isReleaseAlreadyExistsError(error)) {
+        throw error;
+      }
+      core.info(
+        `Release for tag ${gitTag} already exists; skipping release creation.`,
+      );
+    }
   }
 
   core.endGroup();
+};
+
+const isReleaseAlreadyExistsError = (error: unknown): boolean => {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const status = (error as { status?: number }).status;
+  const message = error instanceof Error ? error.message : '';
+  return status === 422 && message.includes('already_exists');
 };
 
 const publishPackages = async () => {


### PR DESCRIPTION
## Summary

After the Node-20/npm fix (#176), the publish workflow now gets past `npm publish` but fails at the **Create Release** step when re-running a version whose GitHub release/tag was already created by an earlier (failed) run:

```
Create Release
  Creating release for tag: v4.6.12
  Error: Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}
  Error: Process completed with exit code 1.
```

`createRelease` called `octokit.rest.repos.createRelease` unconditionally, so a pre-existing release tag aborted the whole script — and because the `distTag` output is set *after* this call, the failure also blocked the subsequent npm-publish step from running at all.

This makes release creation idempotent: if the create call fails because the release already exists (HTTP 422 / `already_exists`), we log and continue instead of throwing, so a re-run proceeds to (re)publish any packages still missing from npm (the publish step already skips versions already on the registry).

```ts
try {
  await octokit.rest.repos.createRelease({ ...tag_name: gitTag });
} catch (error) {
  if (!isReleaseAlreadyExistsError(error)) throw error; // status 422 + message includes 'already_exists'
  core.info(`Release for tag ${gitTag} already exists; skipping release creation.`);
}
```

Net effect: publishing is now fully re-runnable — a partially-completed release (GitHub release created, some/all npm packages published or not) can be retried to completion without manual cleanup of the release/tag.

Note: this `release` action package has no test harness (only a placeholder `index.spec.ts`, no jest configured), so no unit test is added; the change is a small, self-contained guard in the CI script. Verified `octokit` surfaces this collision as `status: 422` with an `already_exists` message (matching the workflow log above).

Link to Devin session: https://dynamicxyz.devinenterprise.com/sessions/5eed2ffd38f74488b9a426aca80d2769
Requested by: @carlascarvalho