### PR TITLE
fix(metamask): open native deep link on iOS for signing (evm + solana)

### DIFF
--- a/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.spec.ts
+++ b/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.spec.ts
@@ -1,11 +1,20 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { type EthereumWalletConnectorOpts } from '@dynamic-labs/ethereum-core';
+import { isIOS, PlatformService } from '@dynamic-labs/utils';
 import { MetaMaskEvmWalletConnector } from './MetaMaskEvmWalletConnector.js';
 import { MetaMaskSdkClient } from './MetaMaskSdkClient.js';
 
 jest.mock('@metamask/connect-evm', () => ({
   createEVMClient: jest.fn(),
 }));
+
+jest.mock('@dynamic-labs/utils', () => ({
+  isIOS: jest.fn(),
+  PlatformService: { openURL: jest.fn() },
+}));
+
+const isIOSMock = isIOS as jest.Mock;
+const openURLMock = PlatformService.openURL as jest.Mock;
 
 jest.mock('@dynamic-labs/ethereum', () => {
   class EthereumInjectedConnector {
@@ -402,6 +411,60 @@ describe('MetaMaskEvmWalletConnector', () => {
       expect(mockProvider.request).toHaveBeenCalledWith({
         method: 'eth_chainId',
       });
+    });
+
+    it('opens the MetaMask native deep link for signing methods on iOS', async () => {
+      isIOSMock.mockReturnValue(true);
+      const mockProvider = {
+        selectedAccount: '0x123',
+        request: jest.fn().mockResolvedValue('0xsignature'),
+        on: jest.fn(),
+        removeListener: jest.fn(),
+      };
+      (MetaMaskSdkClient.getProvider as jest.Mock).mockReturnValue(
+        mockProvider,
+      );
+
+      const provider = connector.findProvider();
+      await provider?.request({ method: 'personal_sign', params: [] });
+
+      expect(openURLMock).toHaveBeenCalledWith('metamask://', 'self');
+    });
+
+    it('does not open a deep link for read-only methods on iOS', async () => {
+      isIOSMock.mockReturnValue(true);
+      const mockProvider = {
+        selectedAccount: '0x123',
+        request: jest.fn().mockResolvedValue('0x1'),
+        on: jest.fn(),
+        removeListener: jest.fn(),
+      };
+      (MetaMaskSdkClient.getProvider as jest.Mock).mockReturnValue(
+        mockProvider,
+      );
+
+      const provider = connector.findProvider();
+      await provider?.request({ method: 'eth_chainId' });
+
+      expect(openURLMock).not.toHaveBeenCalled();
+    });
+
+    it('does not open a deep link for signing methods off iOS', async () => {
+      isIOSMock.mockReturnValue(false);
+      const mockProvider = {
+        selectedAccount: '0x123',
+        request: jest.fn().mockResolvedValue('0xsignature'),
+        on: jest.fn(),
+        removeListener: jest.fn(),
+      };
+      (MetaMaskSdkClient.getProvider as jest.Mock).mockReturnValue(
+        mockProvider,
+      );
+
+      const provider = connector.findProvider();
+      await provider?.request({ method: 'personal_sign', params: [] });
+
+      expect(openURLMock).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.ts
+++ b/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.ts
@@ -8,9 +8,22 @@ import {
   EthereumInjectedConnector,
   type IEthereum,
 } from '@dynamic-labs/ethereum';
+import { isIOS, PlatformService } from '@dynamic-labs/utils';
 
 import { MetaMaskSdkClient } from './MetaMaskSdkClient.js';
 import { toNumericChainId } from './utils.js';
+
+const METAMASK_NATIVE_DEEPLINK = 'metamask://';
+
+// EVM methods that prompt the user in the wallet and therefore need MetaMask to
+// be brought to the foreground on mobile.
+const DEEP_LINK_SIGNING_METHODS = [
+  'personal_sign',
+  'eth_sign',
+  'eth_signTypedData',
+  'eth_signTypedData_v4',
+  'eth_sendTransaction',
+];
 
 /**
  * MetaMask wallet connector for Dynamic.
@@ -87,6 +100,7 @@ export class MetaMaskEvmWalletConnector extends EthereumInjectedConnector {
     return {
       ...provider,
       request: async (args: { method: string; params?: unknown[] }) => {
+        this.openDeepLinkForSigningRequest(args.method);
         const result = await provider.request(args);
         if (
           args.method === 'eth_requestAccounts' &&
@@ -101,6 +115,29 @@ export class MetaMaskEvmWalletConnector extends EthereumInjectedConnector {
       on: provider.on?.bind(provider),
       removeListener: provider.removeListener?.bind(provider),
     } as unknown as IEthereum;
+  }
+
+  /**
+   * On iOS Safari the MetaMask SDK opens its own deep link via `window.open`
+   * outside a user gesture, which the popup blocker suppresses — so the app
+   * never surfaces for signing/transaction requests (Android is unaffected).
+   * Navigate to MetaMask's native scheme instead (`location.assign` via
+   * openURL 'self'), which iOS honours, right before the request is
+   * dispatched. Scoped to iOS and to methods that prompt in the wallet.
+   */
+  private openDeepLinkForSigningRequest(method: string): void {
+    if (
+      this.isInstalledOnBrowser() ||
+      !isIOS() ||
+      !DEEP_LINK_SIGNING_METHODS.includes(method)
+    ) {
+      return;
+    }
+
+    const nativeDeepLink =
+      this.metadata?.deepLinks?.mobile?.native ?? METAMASK_NATIVE_DEEPLINK;
+
+    void PlatformService.openURL(nativeDeepLink, 'self');
   }
 
   override async setupEventListeners(): Promise<void> {

--- a/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.spec.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.spec.ts
@@ -1,5 +1,15 @@
+import { isIOS, PlatformService } from '@dynamic-labs/utils';
+
 import { createWalletStandardAdapter } from './WalletStandardAdapter.js';
 import type { StandardWallet, WalletAccount } from './types.js';
+
+jest.mock('@dynamic-labs/utils', () => ({
+  isIOS: jest.fn(),
+  PlatformService: { openURL: jest.fn() },
+}));
+
+const isIOSMock = isIOS as jest.Mock;
+const openURLMock = PlatformService.openURL as jest.Mock;
 
 jest.mock('@solana/web3.js', () => ({
   PublicKey: jest.fn().mockImplementation((key) => ({ key })),
@@ -215,6 +225,53 @@ describe('createWalletStandardAdapter', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         adapter.signAndSendTransaction(buildLegacyTransaction('a') as any),
       ).rejects.toThrow('No signature returned');
+    });
+  });
+
+  describe('iOS deep link foregrounding', () => {
+    it('opens the MetaMask native deep link for signMessage on iOS', async () => {
+      isIOSMock.mockReturnValue(true);
+      const signMessage = jest
+        .fn()
+        .mockResolvedValue([{ signature: new Uint8Array([5]) }]);
+      const adapter = createWalletStandardAdapter(
+        buildWallet({ 'solana:signMessage': { signMessage } }),
+        getSelectedNetwork,
+      );
+
+      await adapter.signMessage(new Uint8Array([1]));
+
+      expect(openURLMock).toHaveBeenCalledWith('metamask://', 'self');
+    });
+
+    it('opens the MetaMask native deep link for signTransaction on iOS', async () => {
+      isIOSMock.mockReturnValue(true);
+      const signTransaction = jest
+        .fn()
+        .mockResolvedValue([{ signedTransaction: new Uint8Array([9]) }]);
+      const adapter = createWalletStandardAdapter(
+        buildWallet({ 'solana:signTransaction': { signTransaction } }),
+        getSelectedNetwork,
+      );
+
+      await adapter.signTransaction(buildLegacyTransaction('tx') as never);
+
+      expect(openURLMock).toHaveBeenCalledWith('metamask://', 'self');
+    });
+
+    it('does not open a deep link off iOS', async () => {
+      isIOSMock.mockReturnValue(false);
+      const signMessage = jest
+        .fn()
+        .mockResolvedValue([{ signature: new Uint8Array([5]) }]);
+      const adapter = createWalletStandardAdapter(
+        buildWallet({ 'solana:signMessage': { signMessage } }),
+        getSelectedNetwork,
+      );
+
+      await adapter.signMessage(new Uint8Array([1]));
+
+      expect(openURLMock).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.ts
@@ -1,8 +1,27 @@
 import { PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js';
 import type { ISolana } from '@dynamic-labs/solana-core';
+import { isIOS, PlatformService } from '@dynamic-labs/utils';
 import bs58 from 'bs58';
 
 import type { StandardWallet, WalletAccount } from './types.js';
+
+const METAMASK_NATIVE_DEEPLINK = 'metamask://';
+
+/**
+ * On iOS Safari the MetaMask SDK opens its own deep link via `window.open`
+ * outside a user gesture, which the popup blocker suppresses — so the app
+ * never surfaces for signing requests (Android is unaffected). Navigate to
+ * MetaMask's native scheme instead (`location.assign` via openURL 'self'),
+ * which iOS honours, right before the async wallet-standard call. No-op off
+ * iOS, so every other platform keeps its existing behavior.
+ */
+const foregroundMetaMaskOnIos = (): void => {
+  if (!isIOS()) {
+    return;
+  }
+
+  void PlatformService.openURL(METAMASK_NATIVE_DEEPLINK, 'self');
+};
 
 /**
  * Adapts a wallet-standard Wallet into the ISolana interface that Dynamic expects.
@@ -87,6 +106,8 @@ export function createWalletStandardAdapter(
   >(
     transactions: T[],
   ): Promise<T[]> => {
+    foregroundMetaMaskOnIos();
+
     const signFn = features['solana:signTransaction']?.['signTransaction'] as
       | ((
           ...inputs: {
@@ -144,6 +165,8 @@ export function createWalletStandardAdapter(
   >(
     transaction: T,
   ): Promise<{ signature: string }> => {
+    foregroundMetaMaskOnIos();
+
     const sendFn = features['solana:signAndSendTransaction']?.[
       'signAndSendTransaction'
     ] as
@@ -179,6 +202,8 @@ export function createWalletStandardAdapter(
   const signMessage = async (
     message: Uint8Array,
   ): Promise<{ signature: Uint8Array }> => {
+    foregroundMetaMaskOnIos();
+
     const signFn = features['solana:signMessage']?.['signMessage'] as
       | ((input: {
           account: WalletAccount;


### PR DESCRIPTION
## Problem

On **iOS Safari**, MetaMask (both the EVM and Solana SDK connectors) does not come to the foreground for signing / transaction requests — the request just hangs. **Android is unaffected.**

## Root cause

The MetaMask SDK opens its deep link via `window.open` outside a user gesture (it fires asynchronously, per request). iOS Safari's popup blocker suppresses `window.open` outside a gesture, so MetaMask never surfaces.

## Fix

At each connector's signing choke point, on **iOS**, navigate to MetaMask's **native scheme** (`metamask://`, `location.assign` via `openURL('self')`) right before the async wallet call. Scheme navigation is honoured by iOS even outside a gesture and doesn't unload the page (the OS intercepts the scheme), so MetaMask foregrounds for **every** request path — Dynamic auth signing and dapp-initiated requests alike. No-op off iOS.

- **metamask-evm**: wrap the SDK provider's `request` for `personal_sign`, `eth_sign`, `eth_signTypedData[_v4]`, `eth_sendTransaction`. Native link from `metadata.deepLinks.mobile.native`, falling back to `metamask://`.
- **metamask-solana**: foreground in the wallet-standard adapter for `signMessage`, `signTransaction` / `signAllTransactions`, `signAndSendTransaction`.

## Testing

- Unit tests for both connectors: signing methods on iOS open the native deep link (`'self'`); read-only methods and non-iOS do not.
- Verified **end-to-end on a physical iPhone** (iOS Safari via ngrok) against Dynamic's demo-v2: MetaMask now foregrounds for signing after connect, and for dapp-initiated signs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
