### PR TITLE
fix(metamask-solana): open MetaMask native deep link on iOS for signing

### DIFF
--- a/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.spec.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.spec.ts
@@ -1,5 +1,15 @@
+import { isIOS, PlatformService } from '@dynamic-labs/utils';
+
 import { createWalletStandardAdapter } from './WalletStandardAdapter.js';
 import type { StandardWallet, WalletAccount } from './types.js';
+
+jest.mock('@dynamic-labs/utils', () => ({
+  isIOS: jest.fn(),
+  PlatformService: { openURL: jest.fn() },
+}));
+
+const isIOSMock = isIOS as jest.Mock;
+const openURLMock = PlatformService.openURL as jest.Mock;
 
 jest.mock('@solana/web3.js', () => ({
   PublicKey: jest.fn().mockImplementation((key) => ({ key })),
@@ -215,6 +225,53 @@ describe('createWalletStandardAdapter', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         adapter.signAndSendTransaction(buildLegacyTransaction('a') as any),
       ).rejects.toThrow('No signature returned');
+    });
+  });
+
+  describe('iOS deep link foregrounding', () => {
+    it('opens the MetaMask native deep link for signMessage on iOS', async () => {
+      isIOSMock.mockReturnValue(true);
+      const signMessage = jest
+        .fn()
+        .mockResolvedValue([{ signature: new Uint8Array([5]) }]);
+      const adapter = createWalletStandardAdapter(
+        buildWallet({ 'solana:signMessage': { signMessage } }),
+        getSelectedNetwork,
+      );
+
+      await adapter.signMessage(new Uint8Array([1]));
+
+      expect(openURLMock).toHaveBeenCalledWith('metamask://', 'self');
+    });
+
+    it('opens the MetaMask native deep link for signTransaction on iOS', async () => {
+      isIOSMock.mockReturnValue(true);
+      const signTransaction = jest
+        .fn()
+        .mockResolvedValue([{ signedTransaction: new Uint8Array([9]) }]);
+      const adapter = createWalletStandardAdapter(
+        buildWallet({ 'solana:signTransaction': { signTransaction } }),
+        getSelectedNetwork,
+      );
+
+      await adapter.signTransaction(buildLegacyTransaction('tx') as never);
+
+      expect(openURLMock).toHaveBeenCalledWith('metamask://', 'self');
+    });
+
+    it('does not open a deep link off iOS', async () => {
+      isIOSMock.mockReturnValue(false);
+      const signMessage = jest
+        .fn()
+        .mockResolvedValue([{ signature: new Uint8Array([5]) }]);
+      const adapter = createWalletStandardAdapter(
+        buildWallet({ 'solana:signMessage': { signMessage } }),
+        getSelectedNetwork,
+      );
+
+      await adapter.signMessage(new Uint8Array([1]));
+
+      expect(openURLMock).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.ts
@@ -1,8 +1,27 @@
 import { PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js';
 import type { ISolana } from '@dynamic-labs/solana-core';
+import { isIOS, PlatformService } from '@dynamic-labs/utils';
 import bs58 from 'bs58';
 
 import type { StandardWallet, WalletAccount } from './types.js';
+
+const METAMASK_NATIVE_DEEPLINK = 'metamask://';
+
+/**
+ * On iOS Safari the MetaMask SDK opens its own deep link via `window.open`
+ * outside a user gesture, which the popup blocker suppresses — so the app
+ * never surfaces for signing requests (Android is unaffected). Navigate to
+ * MetaMask's native scheme instead (`location.assign` via openURL 'self'),
+ * which iOS honours, right before the async wallet-standard call. No-op off
+ * iOS, so every other platform keeps its existing behavior.
+ */
+const foregroundMetaMaskOnIos = (): void => {
+  if (!isIOS()) {
+    return;
+  }
+
+  void PlatformService.openURL(METAMASK_NATIVE_DEEPLINK, 'self');
+};
 
 /**
  * Adapts a wallet-standard Wallet into the ISolana interface that Dynamic expects.
@@ -87,6 +106,8 @@ export function createWalletStandardAdapter(
   >(
     transactions: T[],
   ): Promise<T[]> => {
+    foregroundMetaMaskOnIos();
+
     const signFn = features['solana:signTransaction']?.['signTransaction'] as
       | ((
           ...inputs: {
@@ -144,6 +165,8 @@ export function createWalletStandardAdapter(
   >(
     transaction: T,
   ): Promise<{ signature: string }> => {
+    foregroundMetaMaskOnIos();
+
     const sendFn = features['solana:signAndSendTransaction']?.[
       'signAndSendTransaction'
     ] as
@@ -179,6 +202,8 @@ export function createWalletStandardAdapter(
   const signMessage = async (
     message: Uint8Array,
   ): Promise<{ signature: Uint8Array }> => {
+    foregroundMetaMaskOnIos();
+
     const signFn = features['solana:signMessage']?.['signMessage'] as
       | ((input: {
           account: WalletAccount;


### PR DESCRIPTION
## Problem

On **iOS Safari**, MetaMask (Solana SDK connector) does not come to the foreground for signing requests — the request just hangs. **Android is unaffected.** Same root cause as the EVM connector fix.

## Root cause

The MetaMask SDK opens its deep link via `window.open` outside a user gesture (it fires asynchronously, per request). iOS Safari's popup blocker suppresses `window.open` outside a gesture, so MetaMask never surfaces.

## Fix

In the wallet-standard adapter (the signing choke point), foreground MetaMask via its **native scheme** (`metamask://`, `location.assign` via `openURL('self')`) at the start of every signing operation — `signMessage`, `signTransaction` / `signAllTransactions`, and `signAndSendTransaction`. Scheme navigation is honoured by iOS even outside a gesture and doesn't unload the page. No-op off iOS.

Mirrors [the metamask-evm fix](https://github.com/dynamic-labs-oss/public-wallet-connectors/pull/178).

## Testing

- Added unit tests: on iOS, `signMessage` and `signTransaction` open the native deep link (`metamask://`, `'self'`); off iOS no deep link is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
