### PR TITLE
Open non-HTTP deep links in same window

### DIFF
--- a/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskSdkClient.spec.ts
+++ b/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskSdkClient.spec.ts
@@ -506,7 +506,25 @@ describe('MetaMaskSdkClient', () => {
       await MetaMaskSdkClient.init(mockConfig);
 
       capturedMobile.preferredOpenLink('metamask://connect?test');
-      expect(mockOpenURL).toHaveBeenCalledWith('metamask://connect?test', 'blank');
+      // App-scheme deep links navigate the current document ('self') rather
+      // than opening a popup ('blank'), which mobile browsers block/reject.
+      expect(mockOpenURL).toHaveBeenCalledWith('metamask://connect?test', 'self');
+    });
+
+    it('preferredOpenLink should open web URLs in a new window', async () => {
+      let capturedMobile: any;
+      mockCreateEVMClient.mockImplementation((options) => {
+        capturedMobile = options.mobile;
+        return Promise.resolve(mockSdk);
+      });
+
+      await MetaMaskSdkClient.init(mockConfig);
+
+      capturedMobile.preferredOpenLink('https://metamask.app.link/connect');
+      expect(mockOpenURL).toHaveBeenCalledWith(
+        'https://metamask.app.link/connect',
+        'blank',
+      );
     });
   });
 
@@ -586,7 +604,7 @@ describe('MetaMaskSdkClient', () => {
       mockOpenURL.mockClear();
 
       MetaMaskSdkClient.retryDeepLink();
-      expect(mockOpenURL).toHaveBeenCalledWith('metamask://connect?session=abc', 'blank');
+      expect(mockOpenURL).toHaveBeenCalledWith('metamask://connect?session=abc', 'self');
     });
 
     it('should do nothing when no connect URI is stored', () => {

--- a/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskSdkClient.ts
+++ b/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskSdkClient.ts
@@ -18,9 +18,20 @@ export interface MetaMaskSdkClientConfig {
  * Opens a deep link using the platform service.
  * Used as the mobile.preferredOpenLink callback for the MetaMask SDK
  * to handle deep links to the MetaMask Mobile app.
+ *
+ * App-scheme deep links (e.g. `metamask://connect/…`) must be opened via a
+ * top-level navigation, not `window.open(..., '_blank')`:
+ *  - Firefox iOS only permits http/https/javascript/data/about schemes for
+ *    popups, so it silently rejects `window.open('metamask://…')`.
+ *  - iOS Safari's popup blocker also suppresses `window.open` outside a user
+ *    gesture (the SDK opens deep links asynchronously).
+ * Navigating the current document (`openURL(link, 'self')` -> location.assign)
+ * is honoured by all iOS browsers, and the OS intercepts the scheme without
+ * unloading the page. Web URLs keep the new-tab behavior.
  */
 const openDeepLink = (link: string): void => {
-  PlatformService.openURL(link, 'blank');
+  const isWebUrl = /^https?:\/\//i.test(link);
+  PlatformService.openURL(link, isWebUrl ? 'blank' : 'self');
 };
 
 /**

--- a/packages/@dynamic-labs-connectors/metamask-solana/src/MetaMaskSolanaSdkClient.spec.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/MetaMaskSolanaSdkClient.spec.ts
@@ -238,7 +238,20 @@ describe('MetaMaskSolanaSdkClient', () => {
 
       const mergeCall = mockMergeOptions.mock.calls[0][0];
       mergeCall.mobile.preferredOpenLink('metamask://connect?test');
-      expect(mockOpenURL).toHaveBeenCalledWith('metamask://connect?test', 'blank');
+      // App-scheme deep links navigate the current document ('self') rather
+      // than opening a popup ('blank'), which mobile browsers block/reject.
+      expect(mockOpenURL).toHaveBeenCalledWith('metamask://connect?test', 'self');
+    });
+
+    it('preferredOpenLink should open web URLs in a new window', async () => {
+      await MetaMaskSolanaSdkClient.init({});
+
+      const mergeCall = mockMergeOptions.mock.calls[0][0];
+      mergeCall.mobile.preferredOpenLink('https://metamask.app.link/connect');
+      expect(mockOpenURL).toHaveBeenCalledWith(
+        'https://metamask.app.link/connect',
+        'blank',
+      );
     });
   });
 
@@ -279,7 +292,7 @@ describe('MetaMaskSolanaSdkClient', () => {
       mockOpenURL.mockClear();
 
       MetaMaskSolanaSdkClient.retryDeepLink();
-      expect(mockOpenURL).toHaveBeenCalledWith('metamask://connect?session=abc', 'blank');
+      expect(mockOpenURL).toHaveBeenCalledWith('metamask://connect?session=abc', 'self');
     });
 
     it('should do nothing when no connect URI is stored', () => {

--- a/packages/@dynamic-labs-connectors/metamask-solana/src/MetaMaskSolanaSdkClient.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/MetaMaskSolanaSdkClient.ts
@@ -30,9 +30,20 @@ export interface MetaMaskSolanaSdkClientConfig {
  * Opens a deep link using the platform service.
  * Used as the mobile.preferredOpenLink callback for the MetaMask SDK
  * to handle deep links to the MetaMask Mobile app.
+ *
+ * App-scheme deep links (e.g. `metamask://connect/…`) must be opened via a
+ * top-level navigation, not `window.open(..., '_blank')`:
+ *  - Firefox iOS only permits http/https/javascript/data/about schemes for
+ *    popups, so it silently rejects `window.open('metamask://…')`.
+ *  - iOS Safari's popup blocker also suppresses `window.open` outside a user
+ *    gesture (the SDK opens deep links asynchronously).
+ * Navigating the current document (`openURL(link, 'self')` -> location.assign)
+ * is honoured by all iOS browsers, and the OS intercepts the scheme without
+ * unloading the page. Web URLs keep the new-tab behavior.
  */
 const openDeepLink = (link: string): void => {
-  PlatformService.openURL(link, 'blank');
+  const isWebUrl = /^https?:\/\//i.test(link);
+  PlatformService.openURL(link, isWebUrl ? 'blank' : 'self');
 };
 
 /**


### PR DESCRIPTION
Detects HTTP(S) URLs and keeps using a new tab for them, but opens app-scheme deep links (e.g. metamask://) via top-level navigation ('self') so iOS browsers and Firefox iOS don't block or reject them. Applied to MetaMask EVM and Solana SDK clients by switching PlatformService.openURL to choose 'blank' for web URLs and 'self' for app schemes, with explanatory comments.