### PR TITLE
fix(metamask): drop redundant manual deep-link foreground (double/stray prompt)

### DIFF
--- a/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.spec.ts
+++ b/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.spec.ts
@@ -1,20 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { type EthereumWalletConnectorOpts } from '@dynamic-labs/ethereum-core';
-import { isIOS, PlatformService } from '@dynamic-labs/utils';
 import { MetaMaskEvmWalletConnector } from './MetaMaskEvmWalletConnector.js';
 import { MetaMaskSdkClient } from './MetaMaskSdkClient.js';
 
 jest.mock('@metamask/connect-evm', () => ({
   createEVMClient: jest.fn(),
 }));
-
-jest.mock('@dynamic-labs/utils', () => ({
-  isIOS: jest.fn(),
-  PlatformService: { openURL: jest.fn() },
-}));
-
-const isIOSMock = isIOS as jest.Mock;
-const openURLMock = PlatformService.openURL as jest.Mock;
 
 jest.mock('@dynamic-labs/ethereum', () => {
   class EthereumInjectedConnector {
@@ -411,60 +402,6 @@ describe('MetaMaskEvmWalletConnector', () => {
       expect(mockProvider.request).toHaveBeenCalledWith({
         method: 'eth_chainId',
       });
-    });
-
-    it('opens the MetaMask native deep link for signing methods on iOS', async () => {
-      isIOSMock.mockReturnValue(true);
-      const mockProvider = {
-        selectedAccount: '0x123',
-        request: jest.fn().mockResolvedValue('0xsignature'),
-        on: jest.fn(),
-        removeListener: jest.fn(),
-      };
-      (MetaMaskSdkClient.getProvider as jest.Mock).mockReturnValue(
-        mockProvider,
-      );
-
-      const provider = connector.findProvider();
-      await provider?.request({ method: 'personal_sign', params: [] });
-
-      expect(openURLMock).toHaveBeenCalledWith('metamask://', 'self');
-    });
-
-    it('does not open a deep link for read-only methods on iOS', async () => {
-      isIOSMock.mockReturnValue(true);
-      const mockProvider = {
-        selectedAccount: '0x123',
-        request: jest.fn().mockResolvedValue('0x1'),
-        on: jest.fn(),
-        removeListener: jest.fn(),
-      };
-      (MetaMaskSdkClient.getProvider as jest.Mock).mockReturnValue(
-        mockProvider,
-      );
-
-      const provider = connector.findProvider();
-      await provider?.request({ method: 'eth_chainId' });
-
-      expect(openURLMock).not.toHaveBeenCalled();
-    });
-
-    it('does not open a deep link for signing methods off iOS', async () => {
-      isIOSMock.mockReturnValue(false);
-      const mockProvider = {
-        selectedAccount: '0x123',
-        request: jest.fn().mockResolvedValue('0xsignature'),
-        on: jest.fn(),
-        removeListener: jest.fn(),
-      };
-      (MetaMaskSdkClient.getProvider as jest.Mock).mockReturnValue(
-        mockProvider,
-      );
-
-      const provider = connector.findProvider();
-      await provider?.request({ method: 'personal_sign', params: [] });
-
-      expect(openURLMock).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.ts
+++ b/packages/@dynamic-labs-connectors/metamask-evm/src/MetaMaskEvmWalletConnector.ts
@@ -8,22 +8,9 @@ import {
   EthereumInjectedConnector,
   type IEthereum,
 } from '@dynamic-labs/ethereum';
-import { isIOS, PlatformService } from '@dynamic-labs/utils';
 
 import { MetaMaskSdkClient } from './MetaMaskSdkClient.js';
 import { toNumericChainId } from './utils.js';
-
-const METAMASK_NATIVE_DEEPLINK = 'metamask://';
-
-// EVM methods that prompt the user in the wallet and therefore need MetaMask to
-// be brought to the foreground on mobile.
-const DEEP_LINK_SIGNING_METHODS = [
-  'personal_sign',
-  'eth_sign',
-  'eth_signTypedData',
-  'eth_signTypedData_v4',
-  'eth_sendTransaction',
-];
 
 /**
  * MetaMask wallet connector for Dynamic.
@@ -100,7 +87,6 @@ export class MetaMaskEvmWalletConnector extends EthereumInjectedConnector {
     return {
       ...provider,
       request: async (args: { method: string; params?: unknown[] }) => {
-        this.openDeepLinkForSigningRequest(args.method);
         const result = await provider.request(args);
         if (
           args.method === 'eth_requestAccounts' &&
@@ -115,29 +101,6 @@ export class MetaMaskEvmWalletConnector extends EthereumInjectedConnector {
       on: provider.on?.bind(provider),
       removeListener: provider.removeListener?.bind(provider),
     } as unknown as IEthereum;
-  }
-
-  /**
-   * On iOS Safari the MetaMask SDK opens its own deep link via `window.open`
-   * outside a user gesture, which the popup blocker suppresses — so the app
-   * never surfaces for signing/transaction requests (Android is unaffected).
-   * Navigate to MetaMask's native scheme instead (`location.assign` via
-   * openURL 'self'), which iOS honours, right before the request is
-   * dispatched. Scoped to iOS and to methods that prompt in the wallet.
-   */
-  private openDeepLinkForSigningRequest(method: string): void {
-    if (
-      this.isInstalledOnBrowser() ||
-      !isIOS() ||
-      !DEEP_LINK_SIGNING_METHODS.includes(method)
-    ) {
-      return;
-    }
-
-    const nativeDeepLink =
-      this.metadata?.deepLinks?.mobile?.native ?? METAMASK_NATIVE_DEEPLINK;
-
-    void PlatformService.openURL(nativeDeepLink, 'self');
   }
 
   override async setupEventListeners(): Promise<void> {

--- a/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.spec.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.spec.ts
@@ -1,15 +1,5 @@
-import { isIOS, PlatformService } from '@dynamic-labs/utils';
-
 import { createWalletStandardAdapter } from './WalletStandardAdapter.js';
 import type { StandardWallet, WalletAccount } from './types.js';
-
-jest.mock('@dynamic-labs/utils', () => ({
-  isIOS: jest.fn(),
-  PlatformService: { openURL: jest.fn() },
-}));
-
-const isIOSMock = isIOS as jest.Mock;
-const openURLMock = PlatformService.openURL as jest.Mock;
 
 jest.mock('@solana/web3.js', () => ({
   PublicKey: jest.fn().mockImplementation((key) => ({ key })),
@@ -225,53 +215,6 @@ describe('createWalletStandardAdapter', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         adapter.signAndSendTransaction(buildLegacyTransaction('a') as any),
       ).rejects.toThrow('No signature returned');
-    });
-  });
-
-  describe('iOS deep link foregrounding', () => {
-    it('opens the MetaMask native deep link for signMessage on iOS', async () => {
-      isIOSMock.mockReturnValue(true);
-      const signMessage = jest
-        .fn()
-        .mockResolvedValue([{ signature: new Uint8Array([5]) }]);
-      const adapter = createWalletStandardAdapter(
-        buildWallet({ 'solana:signMessage': { signMessage } }),
-        getSelectedNetwork,
-      );
-
-      await adapter.signMessage(new Uint8Array([1]));
-
-      expect(openURLMock).toHaveBeenCalledWith('metamask://', 'self');
-    });
-
-    it('opens the MetaMask native deep link for signTransaction on iOS', async () => {
-      isIOSMock.mockReturnValue(true);
-      const signTransaction = jest
-        .fn()
-        .mockResolvedValue([{ signedTransaction: new Uint8Array([9]) }]);
-      const adapter = createWalletStandardAdapter(
-        buildWallet({ 'solana:signTransaction': { signTransaction } }),
-        getSelectedNetwork,
-      );
-
-      await adapter.signTransaction(buildLegacyTransaction('tx') as never);
-
-      expect(openURLMock).toHaveBeenCalledWith('metamask://', 'self');
-    });
-
-    it('does not open a deep link off iOS', async () => {
-      isIOSMock.mockReturnValue(false);
-      const signMessage = jest
-        .fn()
-        .mockResolvedValue([{ signature: new Uint8Array([5]) }]);
-      const adapter = createWalletStandardAdapter(
-        buildWallet({ 'solana:signMessage': { signMessage } }),
-        getSelectedNetwork,
-      );
-
-      await adapter.signMessage(new Uint8Array([1]));
-
-      expect(openURLMock).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.ts
+++ b/packages/@dynamic-labs-connectors/metamask-solana/src/WalletStandardAdapter.ts
@@ -1,27 +1,8 @@
 import { PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js';
 import type { ISolana } from '@dynamic-labs/solana-core';
-import { isIOS, PlatformService } from '@dynamic-labs/utils';
 import bs58 from 'bs58';
 
 import type { StandardWallet, WalletAccount } from './types.js';
-
-const METAMASK_NATIVE_DEEPLINK = 'metamask://';
-
-/**
- * On iOS Safari the MetaMask SDK opens its own deep link via `window.open`
- * outside a user gesture, which the popup blocker suppresses — so the app
- * never surfaces for signing requests (Android is unaffected). Navigate to
- * MetaMask's native scheme instead (`location.assign` via openURL 'self'),
- * which iOS honours, right before the async wallet-standard call. No-op off
- * iOS, so every other platform keeps its existing behavior.
- */
-const foregroundMetaMaskOnIos = (): void => {
-  if (!isIOS()) {
-    return;
-  }
-
-  void PlatformService.openURL(METAMASK_NATIVE_DEEPLINK, 'self');
-};
 
 /**
  * Adapts a wallet-standard Wallet into the ISolana interface that Dynamic expects.
@@ -106,8 +87,6 @@ export function createWalletStandardAdapter(
   >(
     transactions: T[],
   ): Promise<T[]> => {
-    foregroundMetaMaskOnIos();
-
     const signFn = features['solana:signTransaction']?.['signTransaction'] as
       | ((
           ...inputs: {
@@ -165,8 +144,6 @@ export function createWalletStandardAdapter(
   >(
     transaction: T,
   ): Promise<{ signature: string }> => {
-    foregroundMetaMaskOnIos();
-
     const sendFn = features['solana:signAndSendTransaction']?.[
       'signAndSendTransaction'
     ] as
@@ -202,8 +179,6 @@ export function createWalletStandardAdapter(
   const signMessage = async (
     message: Uint8Array,
   ): Promise<{ signature: Uint8Array }> => {
-    foregroundMetaMaskOnIos();
-
     const signFn = features['solana:signMessage']?.['signMessage'] as
       | ((input: {
           account: WalletAccount;


### PR DESCRIPTION
## Problem

After the deep-link popup fix (#181, `openDeepLink` navigates via `location.assign` for app-scheme links), MetaMask opens **twice** on iOS Safari at "click to sign", and a **stray** "Open this page in MetaMask?" prompt appears **after** signing / once already logged in (tapping Open just redirects and does nothing).

## Root cause

Two independent deep-link triggers now fire for the same request:
1. The MetaMask SDK's own `mobile.preferredOpenLink` → `openDeepLink` (now `location.assign`).
2. A **manual** foreground added earlier while `window.open` was still being used and was blocked on iOS:
   - EVM: `openDeepLinkForSigningRequest` in the connector's `request` wrapper.
   - Solana: `foregroundMetaMaskOnIos` in the wallet-standard adapter's sign methods.

Now that `openDeepLink` navigates (works on iOS), the manual foreground is redundant and produces a second `location.assign('metamask://…')` — a double prompt on Safari and a delayed/stray prompt after the request settles. (Firefox happened to coalesce the duplicates, so it looked fine there.)

## Fix

Remove the redundant manual foreground (EVM connector + Solana adapter) and rely solely on the SDK's `preferredOpenLink`, which is a single, correctly-timed deep link on every platform.

## Testing

- Connector unit tests pass (metamask-evm 115, metamask-solana 97).
- Verified end-to-end on a physical iPhone (Safari + Firefox iOS) and Android via ngrok against Dynamic's demo-v2: single "Open in MetaMask" per action, no stray prompt after signing; connect and sign work on all three browsers.

Depends on #181 (already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
